### PR TITLE
Set unknow uarch default l3 cache info

### DIFF
--- a/src/arm/cache.c
+++ b/src/arm/cache.c
@@ -1470,6 +1470,11 @@ void cpuinfo_arm_decode_cache(
 					.associativity = 8,
 					.line_size = 64
 				};
+				*l3 = (struct cpuinfo_cache) {
+					.size = cluster_cores * 256 * 1024,
+					.associativity = 16,
+					.line_size = 64
+				};
 			} else {
 				*l1i = (struct cpuinfo_cache) {
 					.size = 16 * 1024,


### PR DESCRIPTION
Serval project depends on cpuinfo project to detect the CPU cache size, but if a cpu arch is undefined
will cause some procedure function exception, it`s better to set default l3 cache info.