### PR TITLE
Android NDK 21

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
-    "files.associations": {
-        "cpuinfo.h": "c",
-        "typeinfo": "c"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "C_Cpp.default.configurationProvider": "vector-of-bool.cmake-tools",
+    "files.associations": {
+        "cpuinfo.h": "c",
+        "typeinfo": "c"
+    }
+}

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -27,7 +27,7 @@ endif # armeabi-v7a
 ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
 LOCAL_SRC_FILES += src/arm/linux/aarch64-isa.c
 endif # arm64-v8a
-endif # armeabi, armeabi-v7a, or arm64-v8a
+endif # armeabi-v7a, or arm64-v8a
 ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI),x86 x86_64))
 LOCAL_SRC_FILES += \
 	src/x86/init.c \
@@ -59,8 +59,7 @@ else
 LOCAL_CFLAGS += -DCPUINFO_LOG_LEVEL=0
 endif
 LOCAL_STATIC_LIBRARIES := clog
-# include $(BUILD_STATIC_LIBRARY)
-include $(BUILD_SHARED_LIBRARY)
+include $(BUILD_STATIC_LIBRARY)
 
 $(call import-add-path,$(LOCAL_PATH)/deps)
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -5,12 +5,12 @@ LOCAL_MODULE := cpuinfo
 LOCAL_SRC_FILES := \
 	src/init.c \
 	src/api.c \
-	src/linux/current.c \
+	src/cache.c \
 	src/linux/processors.c \
 	src/linux/smallfile.c \
 	src/linux/multiline.c \
 	src/linux/cpulist.c
-ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI),armeabi armeabi-v7a arm64-v8a))
+ifeq ($(TARGET_ARCH_ABI),$(filter $(TARGET_ARCH_ABI),armeabi-v7a arm64-v8a))
 LOCAL_SRC_FILES += \
 	src/arm/uarch.c \
 	src/arm/cache.c \
@@ -21,9 +21,6 @@ LOCAL_SRC_FILES += \
 	src/arm/linux/midr.c \
 	src/arm/linux/hwcap.c \
 	src/arm/android/properties.c
-ifeq ($(TARGET_ARCH_ABI),armeabi)
-LOCAL_SRC_FILES += src/arm/linux/aarch32-isa.c.arm
-endif # armeabi
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
 LOCAL_SRC_FILES += src/arm/linux/aarch32-isa.c
 endif # armeabi-v7a
@@ -62,8 +59,8 @@ else
 LOCAL_CFLAGS += -DCPUINFO_LOG_LEVEL=0
 endif
 LOCAL_STATIC_LIBRARIES := clog
-include $(BUILD_STATIC_LIBRARY)
-
+# include $(BUILD_STATIC_LIBRARY)
+include $(BUILD_SHARED_LIBRARY)
 
 $(call import-add-path,$(LOCAL_PATH)/deps)
 

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_PLATFORM := android-15
+APP_PLATFORM := android-16
 APP_PIE := true
 APP_STL := c++_static
-APP_ABI := armeabi armeabi-v7a arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64


### PR DESCRIPTION
To build this library with NDK 21 two changes needs to be done:
* bump minimum platform version to 16
* drop support for armeabi 

Apart of that there was one missing file in `Android.mk`: `cache.c`.

If you don't want to support new NDK then this PR can safely be closed :) 