### PR TITLE
Mingw crosscompile fix

### DIFF
--- a/src/x86/windows/init.c
+++ b/src/x86/windows/init.c
@@ -8,12 +8,7 @@
 #include <cpuinfo/internal-api.h>
 #include <cpuinfo/log.h>
 
-#if defined(__MINGW32__)
-// Windows header filename must be all lower case on MinGW
 #include <windows.h>
-#else
-#include <Windows.h>
-#endif
 
 #ifdef __GNUC__
   #define CPUINFO_ALLOCA __builtin_alloca

--- a/src/x86/windows/init.c
+++ b/src/x86/windows/init.c
@@ -8,7 +8,12 @@
 #include <cpuinfo/internal-api.h>
 #include <cpuinfo/log.h>
 
+#if defined(__MINGW32__)
+// Windows header filename must be all lower case on MinGW
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif
 
 #ifdef __GNUC__
   #define CPUINFO_ALLOCA __builtin_alloca


### PR DESCRIPTION
This simple fix solves compiling cpuinfo with MinGW gcc/clang cross-compiling on Linux(with case-sensitive filesystem). 

According to this,

https://stackoverflow.com/questions/15466613/lowercase-windows-h-and-uppercase-windows-h-difference

Using lowercase Win32  header filename should be always safe and would be recommended.