### PR TITLE
Fix fp16 arithmetic detection for Cortex-X1 device

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -73,6 +73,7 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 				case UINT32_C(0x4100D050): /* Cortex-A55 */
 				case UINT32_C(0x4100D060): /* Cortex-A65 */
 				case UINT32_C(0x4100D0B0): /* Cortex-A76 */
+                		case UINT32_C(0x4100D440): /* Cortex-X1 */
 				case UINT32_C(0x4100D0C0): /* Neoverse N1 */
 				case UINT32_C(0x4100D0D0): /* Cortex-A77 */
 				case UINT32_C(0x4100D0E0): /* Cortex-A76AE */

--- a/src/arm/linux/aarch64-isa.c
+++ b/src/arm/linux/aarch64-isa.c
@@ -88,6 +88,7 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 		case UINT32_C(0x4100D0B0): /* Cortex-A76 */
 		case UINT32_C(0x4100D0C0): /* Neoverse N1 */
 		case UINT32_C(0x4100D0D0): /* Cortex-A77 */
+        	case UINT32_C(0x4100D440): /* Cortex-X1 */
 		case UINT32_C(0x4100D0E0): /* Cortex-A76AE */
 		case UINT32_C(0x4100D4A0): /* Neoverse E1 */
 		case UINT32_C(0x4800D400): /* Cortex-A76 (HiSilicon) */


### PR DESCRIPTION
FP16 arithmetic detection for Cortext-X1 is not covered. 

CPUs of type Cortext-X1: Snapdragon 888, Samsung Exynos 2100