### PR TITLE
Remove HOMEPAGE_URL from cmake project definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
 PROJECT(
     cpuinfo
     LANGUAGES C CXX
-    HOMEPAGE_URL https://github.com/pytorch/cpuinfo)
+    )
 
 # ---[ Options.
 SET(CPUINFO_LIBRARY_TYPE "default" CACHE STRING "Type of cpuinfo library (shared, static, or default) to build")


### PR DESCRIPTION
HOMEPAGE_URL in cmake's project function is only supported by cmake >= 3.12. In order to support versions down to 3.5, it needs to be removed.