### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -1351,7 +1351,7 @@ static bool match_and_parse_sunxi(
 		return false;
 	}
 
-	/* Compare sunXi platform id and number of cores to tabluted values to decode chipset name */
+	/* Compare sunXi platform id and number of cores to tabulated values to decode chipset name */
 	uint32_t model = 0;
 	char suffix = 0;
 	for (size_t i = 0; i < CPUINFO_COUNT_OF(sunxi_map_entries); i++) {

--- a/src/arm/linux/clusters.c
+++ b/src/arm/linux/clusters.c
@@ -48,7 +48,7 @@ static inline bool bitmask_all(uint32_t bitfield, uint32_t mask) {
  * @param usable_processors - number of processors in the @p processors array with CPUINFO_LINUX_FLAG_VALID flags.
  * @param max_processors - number of elements in the @p processors array.
  * @param[in,out] processors - processor descriptors with pre-parsed POSSIBLE and PRESENT flags, minimum/maximum
- *                             frequency, MIDR infromation, and core cluster (package siblings list) information.
+ *                             frequency, MIDR information, and core cluster (package siblings list) information.
  *
  * @retval true if the heuristic successfully assigned all processors into clusters of cores.
  * @retval false if known details about processors contradict the heuristic configuration of core clusters.
@@ -292,9 +292,9 @@ bool cpuinfo_arm_linux_detect_core_clusters_by_heuristic(
  *   - Processors assigned to these clusters stay assigned to the same clusters
  *   - No new processors are added to these clusters
  * - Processors without pre-assigned cluster are clustered in one sequential scan:
- *   - If known details (min/max frequency, MIDR components) of a processor are compatible with a preceeding
- *     processor, without pre-assigned cluster, the processor is assigned to the cluster of the preceeding processor.
- *   - If known details (min/max frequency, MIDR components) of a processor are not compatible with a preceeding
+ *   - If known details (min/max frequency, MIDR components) of a processor are compatible with a preceding
+ *     processor, without pre-assigned cluster, the processor is assigned to the cluster of the preceding processor.
+ *   - If known details (min/max frequency, MIDR components) of a processor are not compatible with a preceding
  *     processor, the processor is assigned to a newly created cluster.
  *
  * The function must be called after parsing OS-provided information on core clusters, and usually is called only
@@ -309,7 +309,7 @@ bool cpuinfo_arm_linux_detect_core_clusters_by_heuristic(
  *
  * @param max_processors - number of elements in the @p processors array.
  * @param[in,out] processors - processor descriptors with pre-parsed POSSIBLE and PRESENT flags, minimum/maximum
- *                             frequency, MIDR infromation, and core cluster (package siblings list) information.
+ *                             frequency, MIDR information, and core cluster (package siblings list) information.
  *
  * @retval true if the heuristic successfully assigned all processors into clusters of cores.
  * @retval false if known details about processors contradict the heuristic configuration of core clusters.
@@ -331,7 +331,7 @@ void cpuinfo_arm_linux_detect_core_clusters_by_sequential_scan(
 				if (cluster_flags & CPUINFO_LINUX_FLAG_MIN_FREQUENCY) {
 					if (cluster_min_frequency != processors[i].min_frequency) {
 						cpuinfo_log_info(
-							"minimum frequency of processor %"PRIu32" (%"PRIu32" KHz) is different than of preceeding cluster (%"PRIu32" KHz); "
+							"minimum frequency of processor %"PRIu32" (%"PRIu32" KHz) is different than of preceding cluster (%"PRIu32" KHz); "
 							"processor %"PRIu32" starts to a new cluster",
 							i, processors[i].min_frequency, cluster_min_frequency, i);
 						goto new_cluster;
@@ -346,7 +346,7 @@ void cpuinfo_arm_linux_detect_core_clusters_by_sequential_scan(
 				if (cluster_flags & CPUINFO_LINUX_FLAG_MAX_FREQUENCY) {
 					if (cluster_max_frequency != processors[i].max_frequency) {
 						cpuinfo_log_debug(
-							"maximum frequency of processor %"PRIu32" (%"PRIu32" KHz) is different than of preceeding cluster (%"PRIu32" KHz); "
+							"maximum frequency of processor %"PRIu32" (%"PRIu32" KHz) is different than of preceding cluster (%"PRIu32" KHz); "
 							"processor %"PRIu32" starts a new cluster",
 							i, processors[i].max_frequency, cluster_max_frequency, i);
 						goto new_cluster;
@@ -361,7 +361,7 @@ void cpuinfo_arm_linux_detect_core_clusters_by_sequential_scan(
 				if (cluster_flags & CPUINFO_ARM_LINUX_VALID_IMPLEMENTER) {
 					if ((cluster_midr & CPUINFO_ARM_MIDR_IMPLEMENTER_MASK) != (processors[i].midr & CPUINFO_ARM_MIDR_IMPLEMENTER_MASK)) {
 						cpuinfo_log_debug(
-							"CPU Implementer of processor %"PRIu32" (0x%02"PRIx32") is different than of preceeding cluster (0x%02"PRIx32"); "
+							"CPU Implementer of processor %"PRIu32" (0x%02"PRIx32") is different than of preceding cluster (0x%02"PRIx32"); "
 							"processor %"PRIu32" starts to a new cluster",
 							i, midr_get_implementer(processors[i].midr), midr_get_implementer(cluster_midr), i);
 						goto new_cluster;
@@ -417,11 +417,11 @@ void cpuinfo_arm_linux_detect_core_clusters_by_sequential_scan(
 				}
 			}
 
-			/* All checks passed, attach processor to the preceeding cluster */
+			/* All checks passed, attach processor to the preceding cluster */
 			cluster_processors++;
 			processors[i].package_leader_id = cluster_start;
 			processors[i].flags |= CPUINFO_LINUX_FLAG_PACKAGE_CLUSTER;
-			cpuinfo_log_debug("assigned processor %"PRIu32" to preceeding cluster of processor %"PRIu32, i, cluster_start);
+			cpuinfo_log_debug("assigned processor %"PRIu32" to preceding cluster of processor %"PRIu32, i, cluster_start);
 			continue;
 
 new_cluster:

--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -510,7 +510,7 @@ void cpuinfo_arm_linux_init(void) {
 	uint32_t l2_count = 0, l3_count = 0, big_l3_size = 0, cluster_id = UINT32_MAX;
 	/* Indication whether L3 (if it exists) is shared between all cores */
 	bool shared_l3 = true;
-	/* Populate cache infromation structures in l1i, l1d */
+	/* Populate cache information structures in l1i, l1d */
 	for (uint32_t i = 0; i < valid_processors; i++) {
 		if (arm_linux_processors[i].package_leader_id == arm_linux_processors[i].system_processor_id) {
 			cluster_id += 1;

--- a/src/arm/linux/midr.c
+++ b/src/arm/linux/midr.c
@@ -675,10 +675,10 @@ static bool cpuinfo_arm_linux_detect_cluster_midr_by_big_little_heuristic(
 
 /*
  * Initializes MIDR for leaders of core clusters in a single sequential scan:
- *  - Clusters preceeding the first reported MIDR value are assumed to have default MIDR value.
+ *  - Clusters preceding the first reported MIDR value are assumed to have default MIDR value.
  *  - Clusters following any reported MIDR value to have that MIDR value.
  *
- * @param default_midr - MIDR value that will be assigned to cluster leaders preceeding any reported MIDR value.
+ * @param default_midr - MIDR value that will be assigned to cluster leaders preceding any reported MIDR value.
  * @param processors_count - number of logical processor descriptions in the @p processors array.
  * @param[in,out] processors - array of logical processor descriptions with pre-parsed MIDR, maximum frequency,
  *                             and decoded core cluster (package_leader_id) information.
@@ -833,7 +833,7 @@ uint32_t cpuinfo_arm_linux_detect_cluster_midr(
 			 * 2. For systems with 2 clusters and MIDR known for one cluster, assume big.LITTLE configuration,
 			 *    and estimate MIDR for the other cluster under assumption that MIDR for the big cluster is known.
 			 * 3. Initialize MIDRs for core clusters in a single sequential scan:
-			 *    - Clusters preceeding the first reported MIDR value are assumed to have the last reported MIDR value.
+			 *    - Clusters preceding the first reported MIDR value are assumed to have the last reported MIDR value.
 			 *    - Clusters following any reported MIDR value to have that MIDR value.
 			 */
 

--- a/src/x86/name.c
+++ b/src/x86/name.c
@@ -234,7 +234,7 @@ static bool transform_token(char* token_start, char* token_end, struct parser_st
 				return true;
 			}
 			/*
-			 * Erase everywhing after "SOC" on AMD System-on-Chips, e.g.
+			 * Erase everything after "SOC" on AMD System-on-Chips, e.g.
 			 *  "AMD GX-212JC SOC with Radeon(TM) R2E Graphics  \0"
 			 */
 			if (erase_matching(token_start, token_length, "SOC")) {


### PR DESCRIPTION
There are small typos in:
- src/arm/linux/chipset.c
- src/arm/linux/clusters.c
- src/arm/linux/init.c
- src/arm/linux/midr.c
- src/x86/name.c

Fixes:
- Should read `preceding` rather than `preceeding`.
- Should read `information` rather than `infromation`.
- Should read `tabulated` rather than `tabluted`.
- Should read `everything` rather than `everywhing`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md