### PR TITLE
Use sysctls available in macOS 12/iOS 15 for Apple silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,10 @@ LDFLAGS+= $(pkg-config --libs libcpuinfo)
   - [x] x86-64 (iPhone simulator)
   - [x] ARMv7
   - [x] ARM64
-- [x] OS X
+- [x] macOS
   - [x] x86
   - [x] x86-64
+  - [x] ARM64 (Apple silicon)
 - [x] Windows
   - [x] x86
   - [x] x86-64

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -1468,6 +1468,7 @@ static inline bool cpuinfo_has_x86_sha(void) {
 		bool dot;
 		bool jscvt;
 		bool fcma;
+		bool fhm;
 
 		bool aes;
 		bool sha1;
@@ -1732,6 +1733,14 @@ static inline bool cpuinfo_has_arm_jscvt(void) {
 static inline bool cpuinfo_has_arm_fcma(void) {
 	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 		return cpuinfo_isa.fcma;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_arm_fhm(void) {
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+		return cpuinfo_isa.fhm;
 	#else
 		return false;
 	#endif

--- a/src/arm/linux/aarch64-isa.c
+++ b/src/arm/linux/aarch64-isa.c
@@ -124,4 +124,8 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 	if (features2 & CPUINFO_ARM_LINUX_FEATURE2_SVE2) {
 		isa->sve2 = true;
 	}
+	if (features & CPUINFO_ARM_LINUX_FEATURE_ASIMDFHM) {
+		isa->fhm = true;
+	}
+
 }

--- a/src/arm/linux/cpuinfo.c
+++ b/src/arm/linux/cpuinfo.c
@@ -283,6 +283,8 @@ static void parse_features(
 					#if CPUINFO_ARCH_ARM64
 						processor->features |= CPUINFO_ARM_LINUX_FEATURE_ASIMDRDM;
 					#endif
+				} else if (memcmp(feature_start, "asimdfhm", feature_length) == 0) {
+					processor->features |= CPUINFO_ARM_LINUX_FEATURE_ASIMDFHM;
 #if CPUINFO_ARCH_ARM
 				} else if (memcmp(feature_start, "fastmult", feature_length) == 0) {
 					processor->features |= CPUINFO_ARM_LINUX_FEATURE_FASTMULT;

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -133,6 +133,8 @@ int main(int argc, char** argv) {
 		printf("\tVFPv4: %s\n", cpuinfo_has_arm_vfpv4() ? "yes" : "no");
 		printf("\tVFPv4+D32: %s\n", cpuinfo_has_arm_vfpv4_d32() ? "yes" : "no");
 		printf("\tVJCVT: %s\n", cpuinfo_has_arm_jscvt() ? "yes" : "no");
+		printf("\tFMLAL/FMLSL: %s\n", cpuinfo_has_arm_fhm() ? "yes" : "no");
+
 
 	printf("SIMD extensions:\n");
 		printf("\tWMMX: %s\n", cpuinfo_has_arm_wmmx() ? "yes" : "no");
@@ -144,6 +146,7 @@ int main(int argc, char** argv) {
 		printf("\tNEON FP16 arithmetics: %s\n", cpuinfo_has_arm_neon_fp16_arith() ? "yes" : "no");
 		printf("\tNEON complex: %s\n", cpuinfo_has_arm_fcma() ? "yes" : "no");
 		printf("\tNEON dot product: %s\n", cpuinfo_has_arm_neon_dot() ? "yes" : "no");
+		printf("\tNEON VFMLAL/VFMLSL: %s\n", cpuinfo_has_arm_fhm() ? "yes" : "no");
 
 	printf("Cryptography extensions:\n");
 		printf("\tAES: %s\n", cpuinfo_has_arm_aes() ? "yes" : "no");
@@ -157,6 +160,7 @@ int main(int argc, char** argv) {
 		printf("\tARM v8.1 atomics: %s\n", cpuinfo_has_arm_atomics() ? "yes" : "no");
 		printf("\tARM v8.1 SQRDMLxH: %s\n", cpuinfo_has_arm_neon_rdm() ? "yes" : "no");
 		printf("\tARM v8.2 FP16 arithmetics: %s\n", cpuinfo_has_arm_fp16_arith() ? "yes" : "no");
+		printf("\tARM v8.2 FHM: %s\n", cpuinfo_has_arm_fhm() ? "yes" : "no");
 		printf("\tARM v8.3 dot product: %s\n", cpuinfo_has_arm_neon_dot() ? "yes" : "no");
 		printf("\tARM v8.3 JS conversion: %s\n", cpuinfo_has_arm_jscvt() ? "yes" : "no");
 		printf("\tARM v8.3 complex: %s\n", cpuinfo_has_arm_fcma() ? "yes" : "no");


### PR DESCRIPTION
The patch applies to ARM and should not change any behavior for x86_64 / Intel.  In general, it'll use newer sysctls when they're available, but fallback to previous implementations when they're not present.  Newer sysctls are available in iOS 15 and macOS Monterey 12.

- Added FHM ARM ISA feature
- Added support for Apple chips to have different cache configurations for the different core types in the same package
- Updated cache-info to print various cache configurations if multiple are present
- Updated package.name to also query machdep.cpu.brand_string if decode of hw.machine fails
- Updated README.md to include macOS ARM64 support

Example output:

Previous cpu-info running on macOS / M1:
```
Packages:
        0:
Microarchitectures:
        4x Firestorm
        4x Icestorm
Cores:
        0: 1 processor (0), Apple Firestorm
        1: 1 processor (1), Apple Firestorm
        2: 1 processor (2), Apple Firestorm
        3: 1 processor (3), Apple Firestorm
        4: 1 processor (4), Apple Icestorm
        5: 1 processor (5), Apple Icestorm
        6: 1 processor (6), Apple Icestorm
        7: 1 processor (7), Apple Icestorm
Logical processors:
        0
        1
        2
        3
        4
        5
        6
        7

```
cpu-info running on macOS / M1 after patch:

```
Packages:
        0: Apple M1
Microarchitectures:
        4x Firestorm
        4x Icestorm
Cores:
        0: 1 processor (0), Apple Firestorm
        1: 1 processor (1), Apple Firestorm
        2: 1 processor (2), Apple Firestorm
        3: 1 processor (3), Apple Firestorm
        4: 1 processor (4), Apple Icestorm
        5: 1 processor (5), Apple Icestorm
        6: 1 processor (6), Apple Icestorm
        7: 1 processor (7), Apple Icestorm
Logical processors:
        0
        1
        2
        3
        4
        5
        6
        7

```
Previous isa-info running on macOS / M1:

```
Instruction sets:
        ARM v8.1 atomics: yes
        ARM v8.1 SQRDMLxH: no
        ARM v8.2 FP16 arithmetics: yes
        ARM v8.3 dot product: yes
        ARM v8.3 JS conversion: no
        ARM v8.3 complex: no
SIMD extensions:
        ARM SVE: no
        ARM SVE 2: no
Cryptography extensions:
        AES: yes
        SHA1: yes
        SHA2: yes
        PMULL: yes
        CRC32: yes

```
isa-info running on macOS Monterey 12 / M1 after patch:

```
Instruction sets:
        ARM v8.1 atomics: yes
        ARM v8.1 SQRDMLxH: yes
        ARM v8.2 FP16 arithmetics: yes
        ARM v8.2 FHM: yes
        ARM v8.3 dot product: yes
        ARM v8.3 JS conversion: yes
        ARM v8.3 complex: yes
SIMD extensions:
        ARM SVE: no
        ARM SVE 2: no
Cryptography extensions:
        AES: yes
        SHA1: yes
        SHA2: yes
        PMULL: yes
        CRC32: yes

```
Previous cache-info running on macOS / M1:

```
Max cache size (upper bound): 4194304 bytes
L1 instruction cache: 8 x 128 KB, 4-way set associative (256 sets), 128 byte lines, shared by 1 processors
L1 data cache: 8 x 64 KB, 4-way set associative (128 sets), 128 byte lines, shared by 1 processors
L2 data cache: 4 MB (exclusive), 8-way set associative (4096 sets), 128 byte lines, shared by 8 processors

```
cache-info running on macOS Monterey 12 / M1 after patch:

```
Max cache size (upper bound): 12582912 bytes
L1 instruction cache: 4 x 192 KB, 4-way set associative (384 sets), 128 byte lines, shared by 1 processors
L1 instruction cache: 4 x 128 KB, 4-way set associative (256 sets), 128 byte lines, shared by 1 processors
L1 data cache: 4 x 128 KB, 4-way set associative (256 sets), 128 byte lines, shared by 1 processors
L1 data cache: 4 x 64 KB, 4-way set associative (128 sets), 128 byte lines, shared by 1 processors
L2 data cache: 12 MB (exclusive), 8-way set associative (12288 sets), 128 byte lines, shared by 4 processors
L2 data cache: 4 MB (exclusive), 8-way set associative (4096 sets), 128 byte lines, shared by 4 processors
```