### PR TITLE
Update googletest to 1.11.0 and fix GCC 11 build failed

### DIFF
--- a/cmake/DownloadGoogleTest.cmake
+++ b/cmake/DownloadGoogleTest.cmake
@@ -4,8 +4,8 @@ PROJECT(googletest-download NONE)
 
 INCLUDE(ExternalProject)
 ExternalProject_Add(googletest
-	URL https://github.com/google/googletest/archive/release-1.10.0.zip
-	URL_HASH SHA256=94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91
+	URL https://github.com/google/googletest/archive/release-1.11.0.zip
+	URL_HASH SHA256=353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a
 	SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest"
 	BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest"
 	CONFIGURE_COMMAND ""


### PR DESCRIPTION
Update googletest to 1.11.0
Fix issue with GCC 11 and googletest: #70 
Related:  google/googletest#3219

Tested with these commands:
```
mkdir -p build
cmake -S . -B build -G Ninja
ninja -C build
```