### PR TITLE
Cleanup detection of ARM BF16 extension

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -1466,7 +1466,6 @@ static inline bool cpuinfo_has_x86_sha(void) {
 			bool atomics;
 			bool bf16;
 			bool sve;
-			bool svebf16;
 			bool sve2;
 		#endif
 		bool rdm;
@@ -1629,6 +1628,22 @@ static inline bool cpuinfo_has_arm_vfpv4_d32(void) {
 	#endif
 }
 
+static inline bool cpuinfo_has_arm_fp16_arith(void) {
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+		return cpuinfo_isa.fp16arith;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_arm_bf16(void) {
+	#if CPUINFO_ARCH_ARM64
+		return cpuinfo_isa.bf16;
+	#else
+		return false;
+	#endif
+}
+
 static inline bool cpuinfo_has_arm_wmmx(void) {
 	#if CPUINFO_ARCH_ARM
 		return cpuinfo_isa.wmmx;
@@ -1711,17 +1726,17 @@ static inline bool cpuinfo_has_arm_neon_fp16_arith(void) {
 	#endif
 }
 
-static inline bool cpuinfo_has_arm_fp16_arith(void) {
+static inline bool cpuinfo_has_arm_neon_dot(void) {
 	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
-		return cpuinfo_isa.fp16arith;
+		return cpuinfo_isa.dot;
 	#else
 		return false;
 	#endif
 }
 
-static inline bool cpuinfo_has_arm_neon_dot(void) {
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
-		return cpuinfo_isa.dot;
+static inline bool cpuinfo_has_arm_neon_bf16(void) {
+	#if CPUINFO_ARCH_ARM64
+		return cpuinfo_isa.bf16;
 	#else
 		return false;
 	#endif
@@ -1791,25 +1806,17 @@ static inline bool cpuinfo_has_arm_sve(void) {
 	#endif
 }
 
+static inline bool cpuinfo_has_arm_sve_bf16(void) {
+	#if CPUINFO_ARCH_ARM64
+		return cpuinfo_isa.sve && cpuinfo_isa.bf16;
+	#else
+		return false;
+	#endif
+}
+
 static inline bool cpuinfo_has_arm_sve2(void) {
 	#if CPUINFO_ARCH_ARM64
 		return cpuinfo_isa.sve2;
-	#else
-		return false;
-	#endif
-}
-
-static inline bool cpuinfo_has_arm_bf16(void) {
-	#if CPUINFO_ARCH_ARM64
-		return cpuinfo_isa.bf16;
-	#else
-		return false;
-	#endif
-}
-
-static inline bool cpuinfo_has_arm_svebf16(void) {
-	#if CPUINFO_ARCH_ARM64
-		return cpuinfo_isa.svebf16;
 	#else
 		return false;
 	#endif

--- a/src/arm/linux/aarch64-isa.c
+++ b/src/arm/linux/aarch64-isa.c
@@ -130,10 +130,10 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 	if (features2 & CPUINFO_ARM_LINUX_FEATURE2_SVE2) {
 		isa->sve2 = true;
 	}
-	if (features2 & CPUINFO_ARM_LINUX_FEATURE2_BF16) {
+	// SVEBF16 is set iff SVE and BF16 are both supported, but the SVEBF16 feature flag
+	// was added in Linux kernel before the BF16 feature flag, so we check for either.
+	if (features2 & (CPUINFO_ARM_LINUX_FEATURE2_BF16 | CPUINFO_ARM_LINUX_FEATURE2_SVEBF16)) {
 		isa->bf16 = true;
 	}
-	if (features2 & CPUINFO_ARM_LINUX_FEATURE2_SVEBF16) {
-		isa->svebf16 = true;
-	}
 }
+

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -164,7 +164,6 @@ int main(int argc, char** argv) {
 
 	printf("SIMD extensions:\n");
 		printf("\tARM SVE: %s\n", cpuinfo_has_arm_sve() ? "yes" : "no");
-		printf("\tARM SVE BF16: %s\n", cpuinfo_has_arm_svebf16() ? "yes" : "no");
 		printf("\tARM SVE 2: %s\n", cpuinfo_has_arm_sve2() ? "yes" : "no");
 
 	printf("Cryptography extensions:\n");


### PR DESCRIPTION
- Remove unneeded `svebf16` extension flag, instead use the Linux feature flag to detect `bf16` extension
- Group "fp16 arith" and "bf16" together with other floating-point extensions
- Rename `cpuinfo_has_arm_svebf16` to `cpuinfo_has_arm_sve_bf16`
- Add `cpuinfo_has_arm_neon_bf16` API