### PR TITLE
Fix clog deps target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -168,8 +168,7 @@ cc_library(
         "src/arm/midr.h",
     ],
     deps = [
-        #"@clog",
-        "//deps/clog",
+        "@org_pytorch_cpuinfo//deps/clog",
     ],
 )
 


### PR DESCRIPTION
### Context

I'm trying to pull the latest version of CPU into PyTorch https://github.com/pytorch/pytorch/issues/83594

This needs to refer to the correct workspace name instead of `//`.  Otherwise, it won't work when calling from PyTorch as a submodule, i.e. https://github.com/pytorch/pytorch/runs/7886147111?check_suite_focus=true

```
ERROR: /var/lib/jenkins/workspace/third_party/cpuinfo/BUILD.bazel:103:11: no such package 'deps/clog': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /var/lib/jenkins/workspace/deps/clog and referenced by '//third_party/cpuinfo:cpuinfo_impl'
ERROR: Analysis of target '//third_party/cpuinfo:cpuinfo_impl' failed; build aborted: Analysis failed
```

### Testing

```
bazel build //...
```