### PR TITLE
Fix armv8 linux build

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -174,19 +174,24 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 		}
 
 		if (features & CPUINFO_ARM_LINUX_FEATURE_IWMMXT) {
-			const uint32_t wcid = read_wcid();
-			cpuinfo_log_debug("WCID = 0x%08"PRIx32, wcid);
-			const uint32_t coprocessor_type = (wcid >> 8) & UINT32_C(0xFF);
-			if (coprocessor_type >= 0x10) {
-				isa->wmmx = true;
-				if (coprocessor_type >= 0x20) {
-					isa->wmmx2 = true;
+			#if !defined(__ARM_ARCH_8A__) && !(defined(__ARM_ARCH) && (__ARM_ARCH >= 8))
+				const uint32_t wcid = read_wcid();
+				cpuinfo_log_debug("WCID = 0x%08"PRIx32, wcid);
+				const uint32_t coprocessor_type = (wcid >> 8) & UINT32_C(0xFF);
+				if (coprocessor_type >= 0x10) {
+					isa->wmmx = true;
+					if (coprocessor_type >= 0x20) {
+						isa->wmmx2 = true;
+					}
+				} else {
+					cpuinfo_log_warning("WMMX ISA disabled: OS reported iwmmxt feature, "
+						"but WCID coprocessor type 0x%"PRIx32" indicates no WMMX support",
+						coprocessor_type);
 				}
-			} else {
+			#else
 				cpuinfo_log_warning("WMMX ISA disabled: OS reported iwmmxt feature, "
-					"but WCID coprocessor type 0x%"PRIx32" indicates no WMMX support",
-					coprocessor_type);
-			}
+					"but there is no iWMMXt coprocessor");
+			#endif
 		}
 
 		if ((features & CPUINFO_ARM_LINUX_FEATURE_THUMB) || (architecture_flags & CPUINFO_ARM_LINUX_ARCH_T)) {

--- a/src/arm/linux/cp.h
+++ b/src/arm/linux/cp.h
@@ -35,10 +35,16 @@
 			return mvfr0;
 		}
 	#endif
-
-	static inline uint32_t read_wcid(void) {
-		uint32_t wcid;
-		__asm__ __volatile__("MRC p1, 0, %[wcid], c0, c0" : [wcid] "=r" (wcid));
-		return wcid;
-	}
+	#if !defined(__ARM_ARCH_8A__) && !(defined(__ARM_ARCH) && (__ARM_ARCH >= 8))
+		/*
+		 * In ARMv8, AArch32 state supports only conceptual coprocessors CP10, CP11, CP14, and CP15.
+		 * AArch64 does not support the concept of coprocessors.
+		 * and clang refuses to compile inline assembly when targeting ARMv8+
+		 */
+		static inline uint32_t read_wcid(void) {
+			uint32_t wcid;
+			__asm__ __volatile__("MRC p1, 0, %[wcid], c0, c0" : [wcid] "=r" (wcid));
+			return wcid;
+		}
+	#endif
 #endif


### PR DESCRIPTION
Related to [issue 112](https://github.com/pytorch/cpuinfo/issues/112)

To be honest, I am quite new to working with ARM, so here are some links to support my claims:

1. > In ARMv8, AArch32 state supports only conceptual coprocessors CP10, CP11, CP14, and CP15.

This quote is taken from [ARM Glossary](https://developer.arm.com/documentation/aeg0014/g/Glossary?lang=en)
 
2. > AArch64 does not support the concept of coprocessors.

This quote is taken from [Porting to A64 page](https://developer.arm.com/documentation/den0024/a/Porting-to-A64?lang=en)

3. > And clang refuses to compile inline assembly when targeting ARMv8+

Well, I tried (Armv8a both A32 and A64) and it failed.

Interestingly, it fails even if I try to compile for ARMv8 A32 with different coprocessor argument, despite [Arm Armv8-A A32/T32 Instruction Set Architecture doc](https://developer.arm.com/documentation/ddi0597/2020-12/Base-Instructions/MRC--Move-to-general-purpose-register-from-System-register-?lang=en#iclass_a1)  saying MRC instruction should be available

---

As far as I understand, where could be no wmmx-support in armv8, so this change should be safe.
I think so because:

1. [Current cpuinfo code](https://github.com/pytorch/cpuinfo/blob/de2fa78ebb431db98489e78603e4f77c1f6c5c57/src/arm/linux/aarch32-isa.c#L36)  does not check for wmmx if architecture_version is >= 8

2. I've found that people reffer to iWMMXt as to "coprocessor" (for example in [linux kernel code](https://github.com/greearb/linux-ct-5.4/blob/master/arch/arm/kernel/pj4-cp0.c#L5)), and there seems to be no coprocessors in armv8, so there is no need to try and read wmmx-info.

3. Not very strong evidence, but wikipedia page ["List of ARM processors"](https://en.wikipedia.org/wiki/List_of_ARM_processors) lists no armv8 processor with wmmx support.

---

Side Note 1:

[issue 112](https://github.com/pytorch/cpuinfo/issues/112) says that 
> MRC is not available on armv8 and the function may need to use MRS instead

I have not found any info on how to read wmmx-related information using `MRS`, probably because there is no wmmx in armv8

Side Note 2:

I tried to understand where current wcid handling comes from, and found that the behavior of `coprocessor_type` handling is  the same as [pj4_get_iwmmxt_version](https://github.com/greearb/linux-ct-5.4/blob/master/arch/arm/kernel/pj4-cp0.c#L76) function in linux kernel.
However, linux kernel has [another function](https://github.com/torvalds/linux/blob/5bfc75d92efd494db37f5c4c173d3639d4772966/arch/arm/kernel/xscale-cp0.c#L119) for checking iwmmxt support, with different logic (e.g. it checks coprocessor 0 instead of 1).
My guess that `pj4_get_iwmmxt_version` is relevant to PJ4 processor and `cpu_has_iwmmxt` is relevant to xscale processors, so there might be a chance that cpuinfo does incorrect checks for xscale processors.