### PR TITLE
Add build support for PPC

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -110,6 +110,7 @@ cc_library(
         ":linux_armeabi": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS,
         ":linux_aarch64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS,
         ":linux_mips64": COMMON_SRCS + LINUX_SRCS,
+        ":linux_ppc64le": COMMON_SRCS + LINUX_SRCS,
         ":linux_riscv64": COMMON_SRCS + LINUX_SRCS,
         ":linux_s390x": COMMON_SRCS + LINUX_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
@@ -228,6 +229,11 @@ config_setting(
 config_setting(
     name = "linux_mips64",
     values = {"cpu": "mips64"},
+)
+
+config_setting(
+    name = "linux_ppc64le",
+    values = {"cpu": "ppc"},
 )
 
 config_setting(


### PR DESCRIPTION
Add a `config_setting` for the "ppc"-cpu and include the common sources for linux, similar to the other "exotic" architectures.