### PR TITLE
Use relative path to clog

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -168,7 +168,7 @@ cc_library(
         "src/arm/midr.h",
     ],
     deps = [
-        "@org_pytorch_cpuinfo//deps/clog",
+        "//deps/clog",
     ],
 )
 


### PR DESCRIPTION
- Fix breaking build for external repositories (XNNPack, TensorFlow) which don't define `@org_pytorch_cpuinfo` namespace