### PR TITLE
Added Allwinner 2013 naming scheme support for A-Series.

### DIFF
--- a/scripts/android-arm64-build.sh
+++ b/scripts/android-arm64-build.sh
@@ -47,7 +47,7 @@ CMAKE_ARGS+=("-DANDROID_CPP_FEATURES=exceptions")
 # Use-specified CMake arguments go last to allow overridding defaults
 CMAKE_ARGS+=($@)
 
-cd build/android/arm64-v8a && cmake ../../.. \
+cd build/android/arm64-v8a && cmake ../../../../ \
     "${CMAKE_ARGS[@]}"
 
 # Cross-platform parallel build

--- a/scripts/android-armv7-build.sh
+++ b/scripts/android-armv7-build.sh
@@ -47,7 +47,7 @@ CMAKE_ARGS+=("-DANDROID_CPP_FEATURES=exceptions")
 # Use-specified CMake arguments go last to allow overridding defaults
 CMAKE_ARGS+=($@)
 
-cd build/android/armeabi-v7a && cmake ../../.. \
+cd build/android/armeabi-v7a && cmake ../../../../ \
     "${CMAKE_ARGS[@]}"
 
 # Cross-platform parallel build

--- a/scripts/android-x86-build.sh
+++ b/scripts/android-x86-build.sh
@@ -47,7 +47,7 @@ CMAKE_ARGS+=("-DANDROID_CPP_FEATURES=exceptions")
 # Use-specified CMake arguments go last to allow overridding defaults
 CMAKE_ARGS+=($@)
 
-cd build/android/x86 && cmake ../../.. \
+cd build/android/x86 && cmake ../../../../ \
     "${CMAKE_ARGS[@]}"
 
 # Cross-platform parallel build

--- a/src/arm/android/api.h
+++ b/src/arm/android/api.h
@@ -13,6 +13,7 @@ enum cpuinfo_android_chipset_property {
 	cpuinfo_android_chipset_property_ro_arch,
 	cpuinfo_android_chipset_property_ro_chipname,
 	cpuinfo_android_chipset_property_ro_hardware_chipname,
+	cpuinfo_android_chipset_property_ro_hardware,
 	cpuinfo_android_chipset_property_max,
 };
 

--- a/src/arm/android/properties.c
+++ b/src/arm/android/properties.c
@@ -64,4 +64,9 @@ void cpuinfo_arm_android_parse_properties(struct cpuinfo_android_properties prop
 	const int ro_hardware_chipname_length =
 		cpuinfo_android_property_get("ro.hardware.chipname", properties->ro_hardware_chipname);
 	cpuinfo_log_debug("read ro.hardware.chipname = \"%.*s\"", ro_hardware_chipname_length, properties->ro_hardware_chipname);
+
+	// Added support for "ro.hardware" property.
+	const int ro_hardware_length =
+		cpuinfo_android_property_get("ro.hardware", properties->ro_hardware);
+	cpuinfo_log_debug("read ro.hardware = \"%.*s\"", ro_hardware_length, properties->ro_hardware);
 }

--- a/src/arm/linux/api.h
+++ b/src/arm/linux/api.h
@@ -353,7 +353,7 @@ CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 	CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 		cpuinfo_arm_android_decode_chipset_from_ro_chipname(
 			const char ro_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX],
-			uint32_t cores);
+			uint32_t cores, uint32_t max_cpu_freq_max);
 	CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 		cpuinfo_arm_android_decode_chipset_from_ro_hardware_chipname(
 			const char ro_hardware_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);

--- a/src/arm/linux/api.h
+++ b/src/arm/linux/api.h
@@ -27,6 +27,7 @@
 		char ro_arch[CPUINFO_BUILD_PROP_VALUE_MAX];
 		char ro_chipname[CPUINFO_BUILD_PROP_VALUE_MAX];
 		char ro_hardware_chipname[CPUINFO_BUILD_PROP_VALUE_MAX];
+		char ro_hardware[CPUINFO_BUILD_PROP_VALUE_MAX];
 	};
 #endif
 
@@ -351,7 +352,8 @@ CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 			const char ro_arch[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);
 	CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 		cpuinfo_arm_android_decode_chipset_from_ro_chipname(
-			const char ro_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);
+			const char ro_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX],
+			uint32_t cores);
 	CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 		cpuinfo_arm_android_decode_chipset_from_ro_hardware_chipname(
 			const char ro_hardware_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);

--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -1369,8 +1369,166 @@ static const struct sunxi_map_entry sunxi_map_entries[] = {
 	},
 };
 
+
+struct sunxiwx_map_entry {
+	uint8_t sunxi;
+	uint8_t w;
+	uint8_t p;
+	uint8_t cores;
+	uint16_t model;
+	char suffix;
+};
+
+// TODO add other Allwinner series. 
+static const struct sunxiwx_map_entry sunxiwx_map_entries[] = {
+#if CPUINFO_ARCH_ARM
+	{
+		/* ("sun4iw1p1", 1) -> "A10" */
+		.sunxi = 4,
+		.w = 1,
+		.p = 1,
+		.cores = 1,
+		.model = 10,
+	},
+	{
+		/* ("sun4iw2p1", 1) -> "A13" */
+		.sunxi = 4,
+		.w = 2,
+		.p = 1,
+		.cores = 1,
+		.model = 13,
+	},
+	{
+		/* ("sun4iw2p3", 1) -> "A10s" */
+		.sunxi = 4,
+		.w = 2,
+		.p = 3,
+		.cores = 1,
+		.model = 10,
+		.suffix = 's',
+	},
+	{
+		/* ("sun8iw1p1", 4) -> "A31" */
+		.sunxi = 8,
+		.w = 1,
+		.p = 1,
+		.cores = 4,
+		.model = 31,
+	},
+	{
+		/* ("sun8iw1p2", 4) -> "A31s" */
+		.sunxi = 8,
+		.w = 1,
+		.p = 2,
+		.cores = 4,
+		.model = 31,
+		.suffix = 's',
+	},
+	{
+		/* ("sun8iw2p1", 2) -> "A20" */
+		.sunxi = 8,
+		.w = 2,
+		.p = 1,
+		.cores = 2,
+		.model = 20,
+	},
+	{
+		/* ("sun8iw3p1", 2) -> "A23" */
+		.sunxi = 8,
+		.w = 3,
+		.p = 1,
+		.cores = 2,
+		.model = 23,
+	},
+	{
+		/* ("sun8iw5p1", 4) -> "A33,R16" */
+		.sunxi = 8,
+		.w = 5,
+		.p = 1,
+		.cores = 4,
+		.model = 33,
+	},
+	{
+		/* ("sun8iw6p1", 8) -> "A83T, H8, H80, V66, R58" */
+		.sunxi = 8,
+		.w = 6,
+		.p = 1,
+		.cores = 8,
+		.model = 83,
+		.suffix = 'T',
+	},
+	{
+		/* ("sun8iw11p1", 4) -> "R40, V40, T3, A40i, A20e?" */
+		.sunxi = 8,
+		.w = 11,
+		.p = 1,
+		.cores = 4,
+		.model = 40,
+		.suffix = 'i',
+	},
+	{
+		/* ("sun8iw15p1", 4) -> "A50, MR133, R311" */
+		.sunxi = 8,
+		.w = 15,
+		.p = 1,
+		.cores = 4,
+		.model = 50,
+	},
+	{
+		/* ("sun9iw1p1", 8) -> "A80" */
+		.sunxi = 9,
+		.w = 1,
+		.p = 1,
+		.cores = 8,
+		.model = 80,
+	},
+	{
+		/* ("sun9iw1p2", 8) -> "A80T" */
+		.sunxi = 9,
+		.w = 1,
+		.p = 2,
+		.cores = 8,
+		.model = 80,
+		.suffix = 'T',
+	},
+	
+#endif /* CPUINFO_ARCH_ARM */
+	{
+		/* ("sun50iw1p1", 4) -> "A64, H64, R18" */
+		.sunxi = 50,
+		.w = 1,
+		.p = 1,
+		.cores = 4,
+		.model = 64,
+	},
+	{
+		/* ("sun50iw3p1", 4) -> "A63" */
+		.sunxi = 50,
+		.w = 3,
+		.p = 1,
+		.cores = 4,
+		.model = 63,
+	},
+	{
+		/* ("sun50iw10p1", 4) -> "A100, A133, A53, T509" */
+		.sunxi = 50,
+		.w = 10,
+		.p = 1,
+		.cores = 4,
+		.model = 100,
+	},
+	{
+		/* ("sun55iw3p1", 8) -> "A523" */
+		.sunxi = 55,
+		.w = 3,
+		.p = 1,
+		.cores = 8,
+		.model = 523,
+	},
+};
+
 /**
- * Tries to match /proc/cpuinfo Hardware string to Allwinner /sun\d+i/ signature.
+ * Tries to match /proc/cpuinfo Hardware string to Allwinner /sun\d+i/ signature and /sun\d+i+w\d+p\d/ signature.
  * If the string matches signature, the function decodes Allwinner chipset from the number in the signature and the
  * number of cores, and stores it in \p chipset argument.
  *
@@ -1431,12 +1589,89 @@ static bool match_and_parse_sunxi(
 	/* Compare sunXi platform id and number of cores to tabulated values to decode chipset name */
 	uint32_t model = 0;
 	char suffix = 0;
-	for (size_t i = 0; i < CPUINFO_COUNT_OF(sunxi_map_entries); i++) {
-		if (sunxi_platform == sunxi_map_entries[i].sunxi && cores == sunxi_map_entries[i].cores) {
-			model = sunxi_map_entries[i].model;
-			suffix = sunxi_map_entries[i].suffix;
-			break;
+
+	pos++;
+
+	if (pos == end || end - pos <= 2) {
+		// sunxi signature
+		for (size_t i = 0; i < CPUINFO_COUNT_OF(sunxi_map_entries); i++) {
+			if (sunxi_platform == sunxi_map_entries[i].sunxi && cores == sunxi_map_entries[i].cores) {
+				model = sunxi_map_entries[i].model;
+				suffix = sunxi_map_entries[i].suffix;
+				break;
+			}
 		}
+	} else {
+		// sunxiwx signature
+		/* Validate the 'w' letter */
+		if (*pos != 'w') {
+			return false;
+		}
+
+		/* Expect at least 4 symbols: "w" (1 symbols) + w id (1-2 digits) + "p" (1 symbol) + rev id (1 digit) */
+		if (pos + 4 > end) {
+			return false;
+		}
+
+		pos++;
+
+		/* Check and parse the w id */
+		uint32_t w = 0;
+		{
+			const uint32_t digit = (uint32_t) (uint8_t) (*pos) - '0';
+			if (digit >= 10) {
+				/* Not really a digit */
+				return false;
+			}
+			w = digit;
+		}
+
+		pos++;
+		/* Parse optional second digit of the w id */
+		{
+			const uint32_t digit = (uint32_t) (uint8_t) (*pos) - '0';
+			if (digit < 10) {
+				w = w * 10 + digit;
+				if (++pos == end) {
+					/* Expected one more 'p' letter */
+					return false;
+				}
+			}
+		}
+
+		/* Validate the 'p' letter */
+		if (*pos != 'p') {
+			return false;
+		}
+		if (++pos == end) {
+			/* Expected one more digit */
+			return false;
+		}
+
+		/* Check and parse the p id */
+		uint32_t p = 0;
+		{
+			const uint32_t digit = (uint32_t) (uint8_t) (*pos) - '0';
+			if (digit >= 10) {
+				/* Not really a digit */
+				return false;
+			}
+			p = digit;
+		}
+
+
+		for (size_t i = 0; i < CPUINFO_COUNT_OF(sunxiwx_map_entries); i++) {
+			if (sunxi_platform == sunxiwx_map_entries[i].sunxi 
+				&& cores == sunxiwx_map_entries[i].cores
+				&& w == sunxiwx_map_entries[i].w
+				&& p == sunxiwx_map_entries[i].p) {
+					
+				model = sunxiwx_map_entries[i].model;
+				suffix = sunxiwx_map_entries[i].suffix;
+				break;
+			}
+		}
+
 	}
 
 	if (model == 0) {
@@ -3150,7 +3385,7 @@ struct cpuinfo_arm_chipset cpuinfo_arm_linux_decode_chipset_from_proc_cpuinfo_ha
 	 */
 
 	struct cpuinfo_arm_chipset cpuinfo_arm_android_decode_chipset_from_ro_chipname(
-		const char chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX])
+		const char chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX],uint32_t cores)
 	{
 		struct cpuinfo_arm_chipset chipset;
 		const size_t chipname_length = strnlen(chipname, CPUINFO_BUILD_PROP_VALUE_MAX);
@@ -3200,6 +3435,14 @@ struct cpuinfo_arm_chipset cpuinfo_arm_linux_decode_chipset_from_proc_cpuinfo_ha
 		if (match_sc(chipname, chipname_end, &chipset)) {
 			cpuinfo_log_debug(
 				"matched Spreadtrum SC signature in ro.chipname string \"%.*s\"",
+				(int) chipname_length, chipname);
+			return chipset;
+		}
+
+		/* Match /sun\d+i/ signature and map to Allwinner chipset name */
+		if (match_and_parse_sunxi(chipname, chipname_end, cores, &chipset)) {
+			cpuinfo_log_debug(
+				"matched sunxi (Allwinner Ax) signature in ro.chipname string \"%.*s\"",
 				(int) chipname_length, chipname);
 			return chipset;
 		}
@@ -3677,6 +3920,32 @@ void cpuinfo_arm_chipset_to_string(
 		return *ro_board_platform_chipset;
 	}
 
+	static inline struct cpuinfo_arm_chipset disambiguate_allwinner_chipset(
+		const struct cpuinfo_arm_chipset proc_cpuinfo_hardware_chipset[restrict static 1],
+		const struct cpuinfo_arm_chipset ro_product_board_chipset[restrict static 1],
+		const struct cpuinfo_arm_chipset ro_board_platform_chipset[restrict static 1],
+		const struct cpuinfo_arm_chipset ro_chipname_chipset[restrict static 1],
+		const struct cpuinfo_arm_chipset ro_hardware_chipname_chipset[restrict static 1],
+		const struct cpuinfo_arm_chipset ro_hardware_chipset[restrict static 1])
+	{
+		if (ro_hardware_chipset->series != cpuinfo_arm_chipset_series_unknown) {
+			return *ro_hardware_chipset;
+		}
+		if (ro_hardware_chipname_chipset->series != cpuinfo_arm_chipset_series_unknown) {
+			return *ro_hardware_chipname_chipset;
+		}
+		if (ro_chipname_chipset->series != cpuinfo_arm_chipset_series_unknown) {
+			return *ro_chipname_chipset;
+		}
+		if (proc_cpuinfo_hardware_chipset->series != cpuinfo_arm_chipset_series_unknown) {
+			return *proc_cpuinfo_hardware_chipset;
+		}
+		if (ro_product_board_chipset->series != cpuinfo_arm_chipset_series_unknown) {
+			return *ro_product_board_chipset;
+		}
+		return *ro_board_platform_chipset;
+	}
+
 	/*
 	 * Decodes chipset name from Android system properties:
 	 * - /proc/cpuinfo Hardware string
@@ -3722,9 +3991,11 @@ void cpuinfo_arm_chipset_to_string(
 			[cpuinfo_android_chipset_property_ro_arch] =
 				cpuinfo_arm_android_decode_chipset_from_ro_arch(properties->ro_arch),
 			[cpuinfo_android_chipset_property_ro_chipname] =
-				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_chipname),
+				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_chipname, cores),
 			[cpuinfo_android_chipset_property_ro_hardware_chipname] =
-				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_hardware_chipname),
+				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_hardware_chipname, cores),
+			[cpuinfo_android_chipset_property_ro_hardware] =
+				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_hardware, cores),
 		};
 		enum cpuinfo_arm_chipset_vendor vendor = cpuinfo_arm_chipset_vendor_unknown;
 		for (size_t i = 0; i < cpuinfo_android_chipset_property_max; i++) {
@@ -3827,6 +4098,14 @@ void cpuinfo_arm_chipset_to_string(
 								&chipsets[cpuinfo_android_chipset_property_ro_product_board],
 								&chipsets[cpuinfo_android_chipset_property_ro_board_platform],
 								&chipsets[cpuinfo_android_chipset_property_ro_chipname]);
+						case cpuinfo_arm_chipset_vendor_allwinner:
+							return disambiguate_allwinner_chipset(
+								&chipsets[cpuinfo_android_chipset_property_proc_cpuinfo_hardware],
+								&chipsets[cpuinfo_android_chipset_property_ro_product_board],
+								&chipsets[cpuinfo_android_chipset_property_ro_board_platform],
+								&chipsets[cpuinfo_android_chipset_property_ro_chipname],
+								&chipsets[cpuinfo_android_chipset_property_ro_hardware_chipname],
+								&chipsets[cpuinfo_android_chipset_property_ro_hardware]);
 						default:
 							cpuinfo_log_error(
 								"chipset detection failed: "

--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -226,12 +226,40 @@ void cpuinfo_arm_linux_init(void) {
 		}
 	}
 
+	/* Detect min/max frequency and package ID */
+	/* This should run before decode_chipset to get max_frequency */
+	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
+		if (bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			const uint32_t max_frequency = cpuinfo_linux_get_processor_max_frequency(i);
+			if (max_frequency != 0) {
+				arm_linux_processors[i].max_frequency = max_frequency;
+				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MAX_FREQUENCY;
+			}
+
+			const uint32_t min_frequency = cpuinfo_linux_get_processor_min_frequency(i);
+			if (min_frequency != 0) {
+				arm_linux_processors[i].min_frequency = min_frequency;
+				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MIN_FREQUENCY;
+			}
+
+			if (cpuinfo_linux_get_processor_package_id(i, &arm_linux_processors[i].package_id)) {
+				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_PACKAGE_ID;
+			}
+		}
+	}
+	uint32_t max_frequency = 0;
+	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
+		if (bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			max_frequency = max_frequency > arm_linux_processors[i].max_frequency ? max_frequency :  arm_linux_processors[i].max_frequency;
+		}
+	}
+
 #if defined(__ANDROID__)
 	const struct cpuinfo_arm_chipset chipset =
-		cpuinfo_arm_android_decode_chipset(&android_properties, valid_processors, 0);
+		cpuinfo_arm_android_decode_chipset(&android_properties, valid_processors, max_frequency);
 #else
 	const struct cpuinfo_arm_chipset chipset =
-		cpuinfo_arm_linux_decode_chipset(proc_cpuinfo_hardware, proc_cpuinfo_revision, valid_processors, 0);
+		cpuinfo_arm_linux_decode_chipset(proc_cpuinfo_hardware, proc_cpuinfo_revision, valid_processors, max_frequency);
 #endif
 
 	#if CPUINFO_ARCH_ARM
@@ -284,26 +312,7 @@ void cpuinfo_arm_linux_init(void) {
 			isa_features, isa_features2, last_midr, &chipset, &cpuinfo_isa);
 	#endif
 
-	/* Detect min/max frequency and package ID */
-	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
-		if (bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
-			const uint32_t max_frequency = cpuinfo_linux_get_processor_max_frequency(i);
-			if (max_frequency != 0) {
-				arm_linux_processors[i].max_frequency = max_frequency;
-				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MAX_FREQUENCY;
-			}
-
-			const uint32_t min_frequency = cpuinfo_linux_get_processor_min_frequency(i);
-			if (min_frequency != 0) {
-				arm_linux_processors[i].min_frequency = min_frequency;
-				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MIN_FREQUENCY;
-			}
-
-			if (cpuinfo_linux_get_processor_package_id(i, &arm_linux_processors[i].package_id)) {
-				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_PACKAGE_ID;
-			}
-		}
-	}
+	
 
 	/* Initialize topology group IDs */
 	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {

--- a/test/name/android-properties-interface.c
+++ b/test/name/android-properties-interface.c
@@ -105,7 +105,7 @@ void cpuinfo_arm_android_parse_ro_chipname(
 	const char chipname[CPUINFO_BUILD_PROP_VALUE_MAX], uint32_t cores, uint32_t max_cpu_freq_max,
 	char chipset_name[CPUINFO_ARM_CHIPSET_NAME_MAX])
 {
-	struct cpuinfo_arm_chipset chipset = cpuinfo_arm_android_decode_chipset_from_ro_chipname(chipname);
+	struct cpuinfo_arm_chipset chipset = cpuinfo_arm_android_decode_chipset_from_ro_chipname(chipname, cores);
 	if (chipset.series == cpuinfo_arm_chipset_series_unknown) {
 		chipset_name[0] = 0;
 	} else {

--- a/test/name/android-properties-interface.c
+++ b/test/name/android-properties-interface.c
@@ -105,7 +105,7 @@ void cpuinfo_arm_android_parse_ro_chipname(
 	const char chipname[CPUINFO_BUILD_PROP_VALUE_MAX], uint32_t cores, uint32_t max_cpu_freq_max,
 	char chipset_name[CPUINFO_ARM_CHIPSET_NAME_MAX])
 {
-	struct cpuinfo_arm_chipset chipset = cpuinfo_arm_android_decode_chipset_from_ro_chipname(chipname, cores);
+	struct cpuinfo_arm_chipset chipset = cpuinfo_arm_android_decode_chipset_from_ro_chipname(chipname, cores, max_cpu_freq_max);
 	if (chipset.series == cpuinfo_arm_chipset_series_unknown) {
 		chipset_name[0] = 0;
 	} else {

--- a/test/name/proc-cpuinfo-hardware.cc
+++ b/test/name/proc-cpuinfo-hardware.cc
@@ -618,6 +618,10 @@ TEST(PROC_CPUINFO_HARDWARE, allwinner_sunxi) {
 		parse_proc_cpuinfo_hardware("sun50iw1p1", 4));
 	EXPECT_EQ("Allwinner A64",
 		parse_proc_cpuinfo_hardware("sun50iw2", 4));
+	EXPECT_EQ("Allwinner A100",
+		parse_proc_cpuinfo_hardware("sun50iw10p1", 4));
+	EXPECT_EQ("Allwinner A523",
+		parse_proc_cpuinfo_hardware("sun55iw3p1", 8));
 #if CPUINFO_ARCH_ARM
 	EXPECT_EQ("Allwinner A80",
 		parse_proc_cpuinfo_hardware("sun9i", 8));

--- a/test/name/ro-chipname.cc
+++ b/test/name/ro-chipname.cc
@@ -198,4 +198,8 @@ TEST(RO_CHIPNAME, allwinner_sunxi) {
 		parse_ro_chipname("sun50iw1", 4));
 	EXPECT_EQ("Allwinner A523",
 		parse_ro_chipname("sun55iw3p1", 8));
+	EXPECT_EQ("Allwinner A100",
+		parse_ro_chipname("sun50iw10p1", 4, 1464000));
+	EXPECT_EQ("Allwinner A133",
+		parse_ro_chipname("sun50iw10p1", 4, 1512000));
 }

--- a/test/name/ro-chipname.cc
+++ b/test/name/ro-chipname.cc
@@ -191,3 +191,11 @@ TEST(RO_CHIPNAME, spreadtrum) {
 	EXPECT_EQ("Spreadtrum SC9830I",
 		parse_ro_chipname("SC9830I"));
 }
+
+
+TEST(RO_CHIPNAME, allwinner_sunxi) {
+	EXPECT_EQ("Allwinner A64",
+		parse_ro_chipname("sun50iw1", 4));
+	EXPECT_EQ("Allwinner A523",
+		parse_ro_chipname("sun55iw3p1", 8));
+}


### PR DESCRIPTION
Allwinner updated their naming scehme since 2013:
[Allwinner_SoC_Family](https://linux-sunxi.org/Allwinner_SoC_Family)

The new scheme is `sunxiwxpx`,  the old scheme `sunxi` is preserved in this PR for compatibility.