### PR TITLE
Add "ro.hardware" property support.

### DIFF
--- a/src/arm/android/api.h
+++ b/src/arm/android/api.h
@@ -13,6 +13,7 @@ enum cpuinfo_android_chipset_property {
 	cpuinfo_android_chipset_property_ro_arch,
 	cpuinfo_android_chipset_property_ro_chipname,
 	cpuinfo_android_chipset_property_ro_hardware_chipname,
+	cpuinfo_android_chipset_property_ro_hardware,
 	cpuinfo_android_chipset_property_max,
 };
 

--- a/src/arm/android/properties.c
+++ b/src/arm/android/properties.c
@@ -64,4 +64,9 @@ void cpuinfo_arm_android_parse_properties(struct cpuinfo_android_properties prop
 	const int ro_hardware_chipname_length =
 		cpuinfo_android_property_get("ro.hardware.chipname", properties->ro_hardware_chipname);
 	cpuinfo_log_debug("read ro.hardware.chipname = \"%.*s\"", ro_hardware_chipname_length, properties->ro_hardware_chipname);
+
+	// Added support for "ro.hardware" property.
+	const int ro_hardware_length =
+		cpuinfo_android_property_get("ro.hardware", properties->ro_hardware);
+	cpuinfo_log_debug("read ro.hardware = \"%.*s\"", ro_hardware_length, properties->ro_hardware);
 }

--- a/src/arm/linux/api.h
+++ b/src/arm/linux/api.h
@@ -27,6 +27,7 @@
 		char ro_arch[CPUINFO_BUILD_PROP_VALUE_MAX];
 		char ro_chipname[CPUINFO_BUILD_PROP_VALUE_MAX];
 		char ro_hardware_chipname[CPUINFO_BUILD_PROP_VALUE_MAX];
+		char ro_hardware[CPUINFO_BUILD_PROP_VALUE_MAX];
 	};
 #endif
 
@@ -351,7 +352,8 @@ CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 			const char ro_arch[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);
 	CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 		cpuinfo_arm_android_decode_chipset_from_ro_chipname(
-			const char ro_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);
+			const char ro_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX],
+			uint32_t cores, uint32_t max_cpu_freq_max);
 	CPUINFO_INTERNAL struct cpuinfo_arm_chipset
 		cpuinfo_arm_android_decode_chipset_from_ro_hardware_chipname(
 			const char ro_hardware_chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX]);

--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -3150,7 +3150,7 @@ struct cpuinfo_arm_chipset cpuinfo_arm_linux_decode_chipset_from_proc_cpuinfo_ha
 	 */
 
 	struct cpuinfo_arm_chipset cpuinfo_arm_android_decode_chipset_from_ro_chipname(
-		const char chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX])
+		const char chipname[restrict static CPUINFO_BUILD_PROP_VALUE_MAX],uint32_t cores, uint32_t max_cpu_freq_max)
 	{
 		struct cpuinfo_arm_chipset chipset;
 		const size_t chipname_length = strnlen(chipname, CPUINFO_BUILD_PROP_VALUE_MAX);
@@ -3722,9 +3722,11 @@ void cpuinfo_arm_chipset_to_string(
 			[cpuinfo_android_chipset_property_ro_arch] =
 				cpuinfo_arm_android_decode_chipset_from_ro_arch(properties->ro_arch),
 			[cpuinfo_android_chipset_property_ro_chipname] =
-				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_chipname),
+				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_chipname, cores, max_cpu_freq_max),
 			[cpuinfo_android_chipset_property_ro_hardware_chipname] =
-				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_hardware_chipname),
+				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_hardware_chipname, cores, max_cpu_freq_max),
+			[cpuinfo_android_chipset_property_ro_hardware] =
+				cpuinfo_arm_android_decode_chipset_from_ro_chipname(properties->ro_hardware, cores, max_cpu_freq_max),
 		};
 		enum cpuinfo_arm_chipset_vendor vendor = cpuinfo_arm_chipset_vendor_unknown;
 		for (size_t i = 0; i < cpuinfo_android_chipset_property_max; i++) {

--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -226,12 +226,40 @@ void cpuinfo_arm_linux_init(void) {
 		}
 	}
 
+	/* Detect min/max frequency and package ID */
+	/* This should run before decode_chipset to get max_frequency */
+	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
+		if (bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			const uint32_t max_frequency = cpuinfo_linux_get_processor_max_frequency(i);
+			if (max_frequency != 0) {
+				arm_linux_processors[i].max_frequency = max_frequency;
+				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MAX_FREQUENCY;
+			}
+
+			const uint32_t min_frequency = cpuinfo_linux_get_processor_min_frequency(i);
+			if (min_frequency != 0) {
+				arm_linux_processors[i].min_frequency = min_frequency;
+				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MIN_FREQUENCY;
+			}
+
+			if (cpuinfo_linux_get_processor_package_id(i, &arm_linux_processors[i].package_id)) {
+				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_PACKAGE_ID;
+			}
+		}
+	}
+	uint32_t max_frequency = 0;
+	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
+		if (bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			max_frequency = max_frequency > arm_linux_processors[i].max_frequency ? max_frequency :  arm_linux_processors[i].max_frequency;
+		}
+	}
+
 #if defined(__ANDROID__)
 	const struct cpuinfo_arm_chipset chipset =
-		cpuinfo_arm_android_decode_chipset(&android_properties, valid_processors, 0);
+		cpuinfo_arm_android_decode_chipset(&android_properties, valid_processors, max_frequency);
 #else
 	const struct cpuinfo_arm_chipset chipset =
-		cpuinfo_arm_linux_decode_chipset(proc_cpuinfo_hardware, proc_cpuinfo_revision, valid_processors, 0);
+		cpuinfo_arm_linux_decode_chipset(proc_cpuinfo_hardware, proc_cpuinfo_revision, valid_processors, max_frequency);
 #endif
 
 	#if CPUINFO_ARCH_ARM
@@ -283,27 +311,6 @@ void cpuinfo_arm_linux_init(void) {
 		cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 			isa_features, isa_features2, last_midr, &chipset, &cpuinfo_isa);
 	#endif
-
-	/* Detect min/max frequency and package ID */
-	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
-		if (bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
-			const uint32_t max_frequency = cpuinfo_linux_get_processor_max_frequency(i);
-			if (max_frequency != 0) {
-				arm_linux_processors[i].max_frequency = max_frequency;
-				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MAX_FREQUENCY;
-			}
-
-			const uint32_t min_frequency = cpuinfo_linux_get_processor_min_frequency(i);
-			if (min_frequency != 0) {
-				arm_linux_processors[i].min_frequency = min_frequency;
-				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_MIN_FREQUENCY;
-			}
-
-			if (cpuinfo_linux_get_processor_package_id(i, &arm_linux_processors[i].package_id)) {
-				arm_linux_processors[i].flags |= CPUINFO_LINUX_FLAG_PACKAGE_ID;
-			}
-		}
-	}
 
 	/* Initialize topology group IDs */
 	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {

--- a/test/name/android-properties-interface.c
+++ b/test/name/android-properties-interface.c
@@ -105,7 +105,7 @@ void cpuinfo_arm_android_parse_ro_chipname(
 	const char chipname[CPUINFO_BUILD_PROP_VALUE_MAX], uint32_t cores, uint32_t max_cpu_freq_max,
 	char chipset_name[CPUINFO_ARM_CHIPSET_NAME_MAX])
 {
-	struct cpuinfo_arm_chipset chipset = cpuinfo_arm_android_decode_chipset_from_ro_chipname(chipname);
+	struct cpuinfo_arm_chipset chipset = cpuinfo_arm_android_decode_chipset_from_ro_chipname(chipname, cores, max_cpu_freq_max);
 	if (chipset.series == cpuinfo_arm_chipset_series_unknown) {
 		chipset_name[0] = 0;
 	} else {


### PR DESCRIPTION
Added "ro.hardware" property support for some Allwinner A series CPU.
Some of this series will not report hardware info in `proc/cpuinfo` file, or any of the listed properties currently. 
