### PR TITLE
Add darwin_x86_64 CPU handling

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -114,6 +114,7 @@ cc_library(
         ":linux_riscv64": COMMON_SRCS + LINUX_SRCS,
         ":linux_s390x": COMMON_SRCS + LINUX_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
+        ":macos_x86_64_legacy": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":macos_arm64": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
         ":windows_x86_64": COMMON_SRCS + X86_SRCS + WINDOWS_X86_SRCS,
         ":android_armv7": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS + ANDROID_ARM_SRCS,
@@ -149,6 +150,7 @@ cc_library(
     linkstatic = select({
         # https://github.com/bazelbuild/bazel/issues/11552
         ":macos_x86_64": False,
+        ":macos_x86_64_legacy": False,
         "//conditions:default": True,
     }),
     # Headers must be in textual_hdrs to allow us to set the standard to C99
@@ -240,10 +242,18 @@ config_setting(
 )
 
 config_setting(
-    name = "macos_x86_64",
+    name = "macos_x86_64_legacy",
     values = {
         "apple_platform_type": "macos",
         "cpu": "darwin",
+    },
+)
+
+config_setting(
+    name = "macos_x86_64",
+    values = {
+        "apple_platform_type": "macos",
+        "cpu": "darwin_x86_64",
     },
 )
 


### PR DESCRIPTION
Currently bazel supports `darwin` and `darwin_x86_64` as meaning the same thing. The fully qualified version is normally used if you're cross compiling from M1 machines to intel machines. I'm also hoping to remove the unqualified version to reduce confusion. This change makes cpuinfo compatible with both for now.