### PR TITLE
Add profiles for Microsoft Windows Dev Kit 2023 and Ampere Altra

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -188,6 +188,8 @@ enum cpuinfo_vendor {
 	 * Processors are variants of AMD cores.
 	 */
 	cpuinfo_vendor_hygon    = 16,
+	/** Ampere Computing LLC. Vendor of ARM64 processor microarchitectures. */
+	cpuinfo_vendor_ampere   = 17,
 
 	/* Active vendors of embedded CPUs */
 

--- a/src/arm/windows/init-by-logical-sys-info.c
+++ b/src/arm/windows/init-by-logical-sys-info.c
@@ -689,7 +689,7 @@ static bool parse_relation_cache_info(
 		current_cache->flags = CPUINFO_CACHE_UNIFIED;
 	}
 
-	for (uint32_t i = 0; i <= info->Cache.GroupCount; i++) {
+	for (uint32_t i = 0; i < info->Cache.GroupCount; i++) {
 	/* Zero GroupCount is valid, GroupMask still can store bits set. */
 		const uint32_t group_id = info->Cache.GroupMasks[i].Group;
 		/* Bitmask representing processors in this group belonging to this package */

--- a/src/arm/windows/init.c
+++ b/src/arm/windows/init.c
@@ -30,6 +30,10 @@ static struct vendor_info vendors[] = {
 	{
 		"Qualcomm",
 		cpuinfo_vendor_qualcomm
+	},
+	{
+		"Ampere(R)",
+		cpuinfo_vendor_ampere
 	}
 };
 
@@ -62,6 +66,32 @@ static struct woa_chip_info woa_chips[] = {
 			{
 				cpuinfo_uarch_cortex_a76,
 				3150000000
+			}
+		}
+	},
+	/* Microsoft Windows Dev Kit 2023 */
+	{
+		"Snapdragon (TM) 8cx Gen 3 @ 3.0 GHz",
+		woa_chip_name_microsoft_sq_3,
+		{
+			{
+				cpuinfo_uarch_cortex_a78,
+				2420000000,
+			},
+			{
+				cpuinfo_uarch_cortex_x1,
+				3000000000
+			}
+		}
+	},
+	/* Ampere Altra */
+	{
+		"Ampere(R) Altra(R) Processor",
+		woa_chip_name_ampere_altra,
+		{
+			{
+				cpuinfo_uarch_neoverse_n1,
+				3000000000
 			}
 		}
 	}

--- a/src/arm/windows/init.c
+++ b/src/arm/windows/init.c
@@ -37,6 +37,17 @@ static struct vendor_info vendors[] = {
 	}
 };
 
+static struct woa_chip_info woa_chip_unknown = {
+	"Unknown",
+	woa_chip_name_unknown,
+	{
+		{
+			cpuinfo_uarch_unknown,
+			0
+		}
+	}
+};
+
 /* Please add new SoC/chip info here! */
 static struct woa_chip_info woa_chips[] = {
 	/* Microsoft SQ1 Kryo 495 4 + 4 cores (3 GHz + 1.80 GHz) */
@@ -102,13 +113,17 @@ BOOL CALLBACK cpuinfo_arm_windows_init(
 {
 	struct woa_chip_info *chip_info = NULL;
 	enum cpuinfo_vendor vendor = cpuinfo_vendor_unknown;
-	bool result = false;
 	
 	set_cpuinfo_isa_fields();
-	result = get_system_info_from_registry(&chip_info, &vendor);	
-	result &= cpu_info_init_by_logical_sys_info(chip_info, vendor);
-	cpuinfo_is_initialized = result;
-	return ((result == true) ? TRUE : FALSE);
+
+	const bool system_result = get_system_info_from_registry(&chip_info, &vendor);
+	if (!system_result) {
+		chip_info = &woa_chip_unknown;
+	}
+
+	cpuinfo_is_initialized = cpu_info_init_by_logical_sys_info(chip_info, vendor);
+
+	return (system_result && cpuinfo_is_initialized ? TRUE : FALSE);
 }
 
 bool get_core_uarch_for_efficiency(

--- a/src/arm/windows/windows-arm-init.h
+++ b/src/arm/windows/windows-arm-init.h
@@ -4,7 +4,9 @@
 enum woa_chip_name {
 	woa_chip_name_microsoft_sq_1 = 0,
 	woa_chip_name_microsoft_sq_2 = 1,
-	woa_chip_name_unknown = 2,
+	woa_chip_name_microsoft_sq_3 = 2,
+	woa_chip_name_ampere_altra = 3,
+	woa_chip_name_unknown = 4,
 	woa_chip_name_last = woa_chip_name_unknown
 };
 


### PR DESCRIPTION
After this change all unit tests pass on those two devices. Also fixes bug of reading past of `Cache.GroupMasks` of `PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX` structure.