### PR TITLE
Add read-only permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Fixes #145.

As mentioned in the issue, it is dangerous to run workflows with write-all permissions. This PR sets build.yml to run with read-only permissions.