### PR TITLE
Adding support for detection of AMD Zen4 CPUs

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -365,6 +365,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_zen2        = 0x0020010A,
 	/** AMD Zen 3 microarchitecture. */
 	cpuinfo_uarch_zen3        = 0x0020010B,
+	/** AMD Zen 4 microarchitecture. */
+	cpuinfo_uarch_zen4        = 0x0020010C,
 
 	/** NSC Geode and AMD Geode GX and LX. */
 	cpuinfo_uarch_geode  = 0x00200200,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -225,6 +225,12 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x50: // Cezanne
 							return cpuinfo_uarch_zen3;
 					}
+					if ((model_info->model >= 0x10 &&model_info->model <= 0x1F) || // Stones
+						(model_info->model >= 0x60 &&model_info->model <= 0x6F) || // Raphael
+						(model_info->model >= 0x70 &&model_info->model <= 0x77) || // Phoenix, Hawkpoint1
+						(model_info->model >= 0x78 &&model_info->model <= 0x7F) || // Phoenix 2, Hawkpoint2
+						(model_info->model >= 0xA0 &&model_info->model <= 0xAF))   // Stones-Dense
+							return cpuinfo_uarch_zen4;
 					break;
 			}
 			break;

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -225,11 +225,11 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x50: // Cezanne
 							return cpuinfo_uarch_zen3;
 					}
-					if ((model_info->model >= 0x10 &&model_info->model <= 0x1F) || // Stones
-						(model_info->model >= 0x60 &&model_info->model <= 0x6F) || // Raphael
-						(model_info->model >= 0x70 &&model_info->model <= 0x77) || // Phoenix, Hawkpoint1
-						(model_info->model >= 0x78 &&model_info->model <= 0x7F) || // Phoenix 2, Hawkpoint2
-						(model_info->model >= 0xA0 &&model_info->model <= 0xAF))   // Stones-Dense
+					if ((model_info->model >= 0x10 && model_info->model <= 0x1F) || // Stones
+						(model_info->model >= 0x60 && model_info->model <= 0x6F) || // Raphael
+						(model_info->model >= 0x70 && model_info->model <= 0x77) || // Phoenix, Hawkpoint1
+						(model_info->model >= 0x78 && model_info->model <= 0x7F) || // Phoenix 2, Hawkpoint2
+						(model_info->model >= 0xA0 && model_info->model <= 0xAF))   // Stones-Dense
 							return cpuinfo_uarch_zen4;
 					break;
 			}

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -131,6 +131,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Zen 2";
 		case cpuinfo_uarch_zen3:
 			return "Zen 3";
+		case cpuinfo_uarch_zen4:
+			return "Zen 4";
 		case cpuinfo_uarch_geode:
 			return "Geode";
 		case cpuinfo_uarch_bobcat:


### PR DESCRIPTION
# added following changes
* new enum `cpuinfo_uarch_zen4` for zen4 CPUs
* added CPU model ranges under CPU family 0x19 for identifying AMD Zen4 CPUs