### PR TITLE
Fill frequency field on arm linux

### DIFF
--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -524,6 +524,7 @@ void cpuinfo_arm_linux_init(void) {
 				.vendor = arm_linux_processors[i].vendor,
 				.uarch = arm_linux_processors[i].uarch,
 				.midr = arm_linux_processors[i].midr,
+				.frequency = arm_linux_processors[i].max_frequency,
 			};
 		}
 
@@ -544,6 +545,7 @@ void cpuinfo_arm_linux_init(void) {
 		cores[i].vendor = arm_linux_processors[i].vendor;
 		cores[i].uarch = arm_linux_processors[i].uarch;
 		cores[i].midr = arm_linux_processors[i].midr;
+		cores[i].frequency = arm_linux_processors[i].max_frequency;
 		linux_cpu_to_core_map[arm_linux_processors[i].system_processor_id] = &cores[i];
 
 		if (linux_cpu_to_uarch_index_map != NULL) {


### PR DESCRIPTION
Copied the linux arm implementation value of the max frequency to public `cpuinfo_core.frequency` and `cpuinfo_cluster.frequency`.

I'm not sure if `cpuinfo_*.frequency` is meant to represent the current or max frequency. It is not apperent to me from the struct member comments. This patch assumes max is meant.