### PR TITLE
Fix detection of CPU vendor on ARM

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -188,8 +188,6 @@ enum cpuinfo_vendor {
 	 * Processors are variants of AMD cores.
 	 */
 	cpuinfo_vendor_hygon    = 16,
-	/** Ampere Computing LLC. Vendor of ARM64 processor microarchitectures. */
-	cpuinfo_vendor_ampere   = 17,
 
 	/* Active vendors of embedded CPUs */
 

--- a/src/arm/windows/windows-arm-init.h
+++ b/src/arm/windows/windows-arm-init.h
@@ -12,6 +12,7 @@ enum woa_chip_name {
 
 /* Topology information hard-coded by SoC/chip name */
 struct core_info_by_chip_name {
+	enum cpuinfo_vendor vendor;
 	enum cpuinfo_uarch uarch;
 	uint64_t frequency; /* Hz */
 };


### PR DESCRIPTION
- `cpuinfo_vendor` is the vendor of the CPU core, not CPU package
- Remove `cpuinfo_vendor_ampere` as cpuinfo currently doesn't detect any cores designed by Ampere Computing