### PR TITLE
Revert "Add support for some special qualcomm SoCs. (#67)"

### DIFF
--- a/src/arm/cache.c
+++ b/src/arm/cache.c
@@ -535,7 +535,6 @@ void cpuinfo_arm_decode_cache(
 								l2_size = 1024 * 1024;
 								break;
 							case 660:
-							case 662:
 								/* Snapdragon 660: 1 MB L2 (little cores only) */
 								l2_size = 1024 * 1024;
 								break;

--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -282,82 +282,6 @@ static bool match_sm(
 	return true;
 }
 
-
-struct special_map_entry {
-	const char* platform;
-	uint16_t model;
-	uint8_t series;
-	char suffix;
-};
-
-static const struct special_map_entry qualcomm_hardware_map_entries[] = {
-		{
-				/* "Kona" -> Qualcomm Kona */
-				.platform = "Kona",
-				.series = cpuinfo_arm_chipset_series_qualcomm_snapdragon,
-				.model = 865,
-		},
-		{
-				/* "Bengal" -> Qualcomm Bengal */
-				.platform = "Bengal",
-				.series = cpuinfo_arm_chipset_series_qualcomm_snapdragon,
-				.model = 662,
-		},
-		{
-				/* "Bengalp" -> Qualcomm Bengalp */
-				.platform = "Bengalp",
-				.series = cpuinfo_arm_chipset_series_qualcomm_snapdragon,
-				.model = 662,
-		},
-		{
-				/* "Lito" -> Qualcomm Lito */
-				.platform = "Lito",
-				.series = cpuinfo_arm_chipset_series_qualcomm_snapdragon,
-				.model = 765,
-				.suffix = 'G'
-		},
-		{
-				/* "Lagoon" -> Qualcomm Lagoon */
-				.platform = "Lagoon",
-				.series = cpuinfo_arm_chipset_series_qualcomm_snapdragon,
-				.model = 0,
-		},
-};
-
-
-int strcicmp(char const *a, char const *b)
-{
-	for (;; a++, b++) {
-		int d = tolower((unsigned char)*a) - tolower((unsigned char)*b);
-		if (d != 0 || !*a)
-			return d;
-	}
-}
-
-static bool match_qualcomm_special(
-		const char* start, const char* end,
-		struct cpuinfo_arm_chipset chipset[restrict static 1])
-{
-	for (size_t i = 0; i < CPUINFO_COUNT_OF(qualcomm_hardware_map_entries); i++) {
-		int length = end - start;
-		if (strcicmp(qualcomm_hardware_map_entries[i].platform, start) == 0 &&
-			qualcomm_hardware_map_entries[i].platform[length] == 0)
-		{
-			*chipset = (struct cpuinfo_arm_chipset) {
-					.vendor = chipset_series_vendor[qualcomm_hardware_map_entries[i].series],
-					.series = (enum cpuinfo_arm_chipset_series) qualcomm_hardware_map_entries[i].series,
-					.model = qualcomm_hardware_map_entries[i].model,
-					.suffix = {
-							[0] = qualcomm_hardware_map_entries[i].suffix,
-					},
-			};
-			return true;
-		}
-	}
-	return false;
-
-}
-
 /**
  * Tries to match /Samsung Exynos\d{4}$/ signature (case-insensitive) for Samsung Exynos chipsets.
  * If match successful, extracts model information into \p chipset argument.
@@ -1829,6 +1753,13 @@ static bool is_tegra(const char* start, const char* end) {
 	return (length == 5 || start[5] == '3');
 }
 
+struct special_map_entry {
+	const char* platform;
+	uint16_t model;
+	uint8_t series;
+	char suffix;
+};
+
 static const struct special_map_entry special_hardware_map_entries[] = {
 #if CPUINFO_ARCH_ARM
 	{
@@ -2387,14 +2318,6 @@ struct cpuinfo_arm_chipset cpuinfo_arm_linux_decode_chipset_from_proc_cpuinfo_ha
 								(int) hardware_length, hardware);
 							return chipset;
 						}
-
-						if (match_qualcomm_special(pos, hardware_end, &chipset)) {
-							cpuinfo_log_debug(
-									"matched Qualcomm signature in /proc/cpuinfo Hardware string \"%.*s\"",
-									(int) hardware_length, hardware);
-							return chipset;
-						}
-
 					}
 					word_start = false;
 					break;


### PR DESCRIPTION
Hard-coding special Hardware strings should be used only as a last resort, as it bloats the library size and doesn't scale to newer chipsets.