### PR TITLE
Use AArch64-only big.LITTLE cores to detect AArch32 ISA

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -68,11 +68,18 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 		 * - Processors with Cortex-A75 cores
 		 * - Processors with Cortex-A76 cores
 		 * - Processors with Cortex-A77 cores
+		 * - Processors with Cortex-A78 cores
+		 * - Processors with Cortex-A510 cores
+		 * - Processors with Cortex-A710 cores
+		 * - Processors with Cortex-A715 cores
+		 * - Processors with Cortex-X1 cores
+		 * - Processors with Cortex-X2 cores
+		 * - Processors with Cortex-X3 cores
 		 * - Processors with Exynos M4 cores
 		 * - Processors with Exynos M5 cores
 		 * - Neoverse N1 cores
-		 * - Neoverse V1 cores
 		 * - Neoverse N2 cores
+		 * - Neoverse V1 cores
 		 */
 		if (chipset->series == cpuinfo_arm_chipset_series_samsung_exynos && chipset->model == 9810) {
 			/* Only little cores of Exynos 9810 support FP16 & RDM */
@@ -83,11 +90,18 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 				case UINT32_C(0x4100D060): /* Cortex-A65 */
 				case UINT32_C(0x4100D0A0): /* Cortex-A75 */
 				case UINT32_C(0x4100D0B0): /* Cortex-A76 */
+				case UINT32_C(0x4100D0C0): /* Neoverse N1 */
 				case UINT32_C(0x4100D0D0): /* Cortex-A77 */
 				case UINT32_C(0x4100D0E0): /* Cortex-A76AE */
+				case UINT32_C(0x4100D400): /* Neoverse V1 */
+				case UINT32_C(0x4100D410): /* Cortex-A78 */
+				case UINT32_C(0x4100D440): /* Cortex-X1 */
 				case UINT32_C(0x4100D460): /* Cortex-A510 */
 				case UINT32_C(0x4100D470): /* Cortex-A710 */
 				case UINT32_C(0x4100D480): /* Cortex-X2 */
+				case UINT32_C(0x4100D490): /* Neoverse N2 */
+				case UINT32_C(0x4100D4D0): /* Cortex-A715 */
+				case UINT32_C(0x4100D4E0): /* Cortex-X3 */
 				case UINT32_C(0x4800D400): /* Cortex-A76 (HiSilicon) */
 				case UINT32_C(0x51008020): /* Kryo 385 Gold (Cortex-A75) */
 				case UINT32_C(0x51008030): /* Kryo 385 Silver (Cortex-A55) */
@@ -103,20 +117,43 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 
 		/*
 		 * NEON VDOT instructions are not indicated in /proc/cpuinfo.
-		 * Use a MIDR-based heuristic to whitelist processors known to support it.
+		 * Use a MIDR-based heuristic to whitelist processors known to support it:
+		 * - Processors with Cortex-A65 cores
+		 * - Processors with Cortex-A76 cores
+		 * - Processors with Cortex-A77 cores
+		 * - Processors with Cortex-A78 cores
+		 * - Processors with Cortex-A510 cores
+		 * - Processors with Cortex-A710 cores
+		 * - Processors with Cortex-A715 cores
+		 * - Processors with Cortex-X1 cores
+		 * - Processors with Cortex-X2 cores
+		 * - Processors with Cortex-X3 cores
+		 * - Processors with Exynos M4 cores
+		 * - Processors with Exynos M5 cores
+		 * - Neoverse N1 cores
+		 * - Neoverse N2 cores
+		 * - Neoverse V1 cores
 		 */
 		switch (midr & (CPUINFO_ARM_MIDR_IMPLEMENTER_MASK | CPUINFO_ARM_MIDR_PART_MASK)) {
+			case UINT32_C(0x4100D060): /* Cortex-A65 */
 			case UINT32_C(0x4100D0B0): /* Cortex-A76 */
+			case UINT32_C(0x4100D0C0): /* Neoverse N1 */
 			case UINT32_C(0x4100D0D0): /* Cortex-A77 */
 			case UINT32_C(0x4100D0E0): /* Cortex-A76AE */
-			case UINT32_C(0x4800D400): /* Cortex-A76 (HiSilicon) */
+			case UINT32_C(0x4100D400): /* Neoverse V1 */
+			case UINT32_C(0x4100D410): /* Cortex-A78 */
+			case UINT32_C(0x4100D440): /* Cortex-X1 */
 			case UINT32_C(0x4100D460): /* Cortex-A510 */
 			case UINT32_C(0x4100D470): /* Cortex-A710 */
 			case UINT32_C(0x4100D480): /* Cortex-X2 */
+			case UINT32_C(0x4100D490): /* Neoverse N2 */
+			case UINT32_C(0x4100D4D0): /* Cortex-A715 */
+			case UINT32_C(0x4100D4E0): /* Cortex-X3 */
+			case UINT32_C(0x4800D400): /* Cortex-A76 (HiSilicon) */
 			case UINT32_C(0x51008040): /* Kryo 485 Gold (Cortex-A76) */
 			case UINT32_C(0x51008050): /* Kryo 485 Silver (Cortex-A55) */
-			case UINT32_C(0x53000030): /* Exynos-M4 */
-			case UINT32_C(0x53000040): /* Exynos-M5 */
+			case UINT32_C(0x53000030): /* Exynos M4 */
+			case UINT32_C(0x53000040): /* Exynos M5 */
 				isa->dot = true;
 				break;
 			case UINT32_C(0x4100D050): /* Cortex A55: revision 1 or later only */


### PR DESCRIPTION
This change extends #162 to ISA detection