### PR TITLE
Add support for linux ppc64le architecture

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -113,6 +113,7 @@ cc_library(
         ":linux_mips64": COMMON_SRCS + LINUX_SRCS,
         ":linux_riscv64": COMMON_SRCS + LINUX_SRCS,
         ":linux_s390x": COMMON_SRCS + LINUX_SRCS,
+        ":linux_ppc64le": COMMON_SRCS + LINUX_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":macos_x86_64_legacy": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":macos_arm64": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
@@ -239,6 +240,11 @@ config_setting(
 config_setting(
     name = "linux_s390x",
     values = {"cpu": "s390x"},
+)
+
+config_setting(
+    name = "linux_ppc64le",
+    values = {"cpu": "ppc"},
 )
 
 config_setting(


### PR DESCRIPTION
This change is needed for cpuinfo to build on linux ppc64le architecture. Without this change, Tensorflow's build fails on ppc64le.