### PR TITLE
Remove redudant ctype.h include

### DIFF
--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -1,4 +1,3 @@
-#include <ctype.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
This include was added in #91, but no longer needed after #165