### PR TITLE
Fix init.c

### DIFF
--- a/src/x86/windows/init.c
+++ b/src/x86/windows/init.c
@@ -17,6 +17,10 @@
 #endif
 
 
+static inline uint32_t max(uint32_t a, uint32_t b) {
+	return a > b ? a : b;
+}
+
 static inline uint32_t bit_mask(uint32_t bits) {
 	return (UINT32_C(1) << bits) - UINT32_C(1);
 }


### PR DESCRIPTION
```
init_win.c: In function 'cpuinfo_x86_windows_init':
init_win.c:130:46: warning: implicit declaration of function 'max' [-Wimplicit-function-declaration]
  130 |         const uint32_t package_bits_offset = max(
      |                                              ^~~
```