### PR TITLE
Add limited support for RISC-V initialization

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,10 @@ ARM_SRCS = [
     "src/arm/uarch.c",
 ]
 
+RISCV_SRCS = [
+    "src/riscv/uarch.c",
+]
+
 # Platform-specific sources and headers
 LINUX_SRCS = [
     "src/linux/cpulist.c",
@@ -81,6 +85,12 @@ LINUX_ARM32_SRCS = LINUX_ARM_SRCS + ["src/arm/linux/aarch32-isa.c"]
 
 LINUX_ARM64_SRCS = LINUX_ARM_SRCS + ["src/arm/linux/aarch64-isa.c"]
 
+LINUX_RISCV_SRCS = [
+    "src/riscv/linux/init.c",
+    "src/riscv/linux/riscv-isa.c",
+    "src/riscv/linux/riscv-hw.c",
+]
+
 ANDROID_ARM_SRCS = [
     "src/arm/android/properties.c",
 ]
@@ -111,7 +121,8 @@ cc_library(
         ":linux_armeabi": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM32_SRCS,
         ":linux_aarch64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS,
         ":linux_mips64": COMMON_SRCS + LINUX_SRCS,
-        ":linux_riscv64": COMMON_SRCS + LINUX_SRCS,
+        ":linux_riscv32": COMMON_SRCS + RISCV_SRCS + LINUX_SRCS + LINUX_RISCV_SRCS,
+        ":linux_riscv64": COMMON_SRCS + RISCV_SRCS + LINUX_SRCS + LINUX_RISCV_SRCS,
         ":linux_s390x": COMMON_SRCS + LINUX_SRCS,
         ":macos_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":macos_x86_64_legacy": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
@@ -121,6 +132,7 @@ cc_library(
         ":android_arm64": COMMON_SRCS + ARM_SRCS + LINUX_SRCS + LINUX_ARM64_SRCS + ANDROID_ARM_SRCS,
         ":android_x86": COMMON_SRCS + X86_SRCS + LINUX_SRCS + LINUX_X86_SRCS,
         ":android_x86_64": COMMON_SRCS + X86_SRCS + LINUX_SRCS + LINUX_X86_SRCS,
+        ":android_riscv64": COMMON_SRCS + RISCV_SRCS + LINUX_SRCS + LINUX_RISCV_SRCS,
         ":ios_x86_64": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":ios_x86": COMMON_SRCS + X86_SRCS + MACH_SRCS + MACH_X86_SRCS,
         ":ios_armv7": COMMON_SRCS + MACH_SRCS + MACH_ARM_SRCS,
@@ -170,6 +182,8 @@ cc_library(
         "src/arm/linux/cp.h",
         "src/arm/api.h",
         "src/arm/midr.h",
+        "src/riscv/api.h",
+        "src/riscv/linux/api.h",
     ],
 )
 
@@ -229,6 +243,11 @@ config_setting(
 config_setting(
     name = "linux_mips64",
     values = {"cpu": "mips64"},
+)
+
+config_setting(
+    name = "linux_riscv32",
+    values = {"cpu": "riscv32"},
 )
 
 config_setting(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ IF(NOT CMAKE_SYSTEM_PROCESSOR)
       "cpuinfo will compile, but cpuinfo_initialize() will always fail.")
     SET(CPUINFO_SUPPORTED_PLATFORM FALSE)
   ENDIF()
-ELSEIF(NOT CPUINFO_TARGET_PROCESSOR MATCHES "^(i[3-6]86|AMD64|x86(_64)?|armv[5-8].*|aarch64|arm64.*|ARM64.*)$")
+ELSEIF(NOT CPUINFO_TARGET_PROCESSOR MATCHES "^(i[3-6]86|AMD64|x86(_64)?|armv[5-8].*|aarch64|arm64.*|ARM64.*|riscv(32|64))$")
   MESSAGE(WARNING
     "Target processor architecture \"${CPUINFO_TARGET_PROCESSOR}\" is not supported in cpuinfo. "
     "cpuinfo will compile, but cpuinfo_initialize() will always fail.")
@@ -209,6 +209,15 @@ IF(CPUINFO_SUPPORTED_PLATFORM)
     IF(CMAKE_SYSTEM_NAME STREQUAL "Android")
       LIST(APPEND CPUINFO_SRCS
         src/arm/android/properties.c)
+    ENDIF()
+  ELSEIF(CPUINFO_TARGET_PROCESSOR MATCHES "^(riscv(32|64))$")
+    LIST(APPEND CPUINFO_SRCS
+      src/riscv/uarch.c)
+    IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      LIST(APPEND CPUINFO_SRCS
+        src/riscv/linux/init.c
+	src/riscv/linux/riscv-hw.c
+	src/riscv/linux/riscv-isa.c)
     ENDIF()
   ENDIF()
 

--- a/configure.py
+++ b/configure.py
@@ -56,6 +56,12 @@ def main(args):
                     sources += [
                         "arm/android/properties.c",
                     ]
+        if build.target.is_riscv:
+            if build.target.is_linux:
+                sources += [
+                    "riscv/linux/init.c",
+                    "riscv/linux/riscv-isa.c",
+                ]
 
         if build.target.is_macos:
             sources += ["mach/topology.c"]

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -46,6 +46,14 @@
 	#endif
 #endif
 
+#if defined(__riscv)
+	#if (__riscv_xlen == 32)
+		#define CPUINFO_ARCH_RISCV32 1
+	#elif (__riscv_xlen == 64)
+		#define CPUINFO_ARCH_RISCV64 1
+	#endif
+#endif
+
 /* Define other architecture-specific macros as 0 */
 
 #ifndef CPUINFO_ARCH_X86
@@ -78,6 +86,14 @@
 
 #ifndef CPUINFO_ARCH_WASMSIMD
 	#define CPUINFO_ARCH_WASMSIMD 0
+#endif
+
+#ifndef CPUINFO_ARCH_RISCV32
+	#define CPUINFO_ARCH_RISCV32 0
+#endif
+
+#ifndef CPUINFO_ARCH_RISCV64
+	#define CPUINFO_ARCH_RISCV64 0
 #endif
 
 #if CPUINFO_ARCH_X86 && defined(_MSC_VER)
@@ -188,6 +204,8 @@ enum cpuinfo_vendor {
 	 * Processors are variants of AMD cores.
 	 */
 	cpuinfo_vendor_hygon    = 16,
+	/** SiFive, Inc. Vendor of RISC-V processor microarchitectures. */
+	cpuinfo_vendor_sifive   = 17,
 
 	/* Active vendors of embedded CPUs */
 
@@ -1861,6 +1879,109 @@ static inline bool cpuinfo_has_arm_sve_bf16(void) {
 static inline bool cpuinfo_has_arm_sve2(void) {
 	#if CPUINFO_ARCH_ARM64
 		return cpuinfo_isa.sve2;
+	#else
+		return false;
+	#endif
+}
+
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	/* This structure is not a part of stable API. Use cpuinfo_has_riscv_* functions instead. */
+	struct cpuinfo_riscv_isa {
+		/**
+		 * Keep fields in line with the canonical order as defined by
+		 * Section 27.11 Subset Naming Convention.
+		 */
+		/* RV32I/64I/128I Base ISA. */
+		bool i;
+		#if CPUINFO_ARCH_RISCV32
+			/* RV32E Base ISA. */
+			bool e;
+		#endif
+		/* Integer Multiply/Divide Extension. */
+		bool m;
+		/* Atomic Extension. */
+		bool a;
+		/* Single-Precision Floating-Point Extension. */
+		bool f;
+		/* Double-Precision Floating-Point Extension. */
+		bool d;
+		/* Compressed Extension. */
+		bool c;
+		/* Vector Extension. */
+		bool v;
+	};
+
+	extern struct cpuinfo_riscv_isa cpuinfo_isa;
+#endif
+
+static inline bool cpuinfo_has_riscv_i(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.i;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_e(void) {
+	#if CPUINFO_ARCH_RISCV32
+		return cpuinfo_isa.e;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_m(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.m;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_a(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.a;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_f(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.f;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_d(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.d;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_g(void) {
+	// The 'G' extension is simply shorthand for 'IMAFD'.
+	return cpuinfo_has_riscv_i()
+		&& cpuinfo_has_riscv_m()
+		&& cpuinfo_has_riscv_a()
+		&& cpuinfo_has_riscv_f()
+		&& cpuinfo_has_riscv_d();
+}
+
+static inline bool cpuinfo_has_riscv_c(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.c;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_riscv_v(void) {
+	#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+		return cpuinfo_isa.v;
 	#else
 		return false;
 	#endif

--- a/src/api.c
+++ b/src/api.c
@@ -30,7 +30,8 @@ uint32_t cpuinfo_packages_count = 0;
 uint32_t cpuinfo_cache_count[cpuinfo_cache_level_max] = { 0 };
 uint32_t cpuinfo_max_cache_size = 0;
 
-#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+    || CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 	struct cpuinfo_uarch_info* cpuinfo_uarchs = NULL;
 	uint32_t cpuinfo_uarchs_count = 0;
 #else
@@ -41,7 +42,8 @@ uint32_t cpuinfo_max_cache_size = 0;
 	uint32_t cpuinfo_linux_cpu_max = 0;
 	const struct cpuinfo_processor** cpuinfo_linux_cpu_to_processor_map = NULL;
 	const struct cpuinfo_core** cpuinfo_linux_cpu_to_core_map = NULL;
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+            || CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 		const uint32_t* cpuinfo_linux_cpu_to_uarch_index_map = NULL;
 	#endif
 #endif
@@ -79,7 +81,8 @@ const struct cpuinfo_uarch_info* cpuinfo_get_uarchs() {
 	if (!cpuinfo_is_initialized) {
 		cpuinfo_log_fatal("cpuinfo_get_%s called before cpuinfo is initialized", "uarchs");
 	}
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+		|| CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 		return cpuinfo_uarchs;
 	#else
 		return &cpuinfo_global_uarch;
@@ -130,7 +133,8 @@ const struct cpuinfo_uarch_info* cpuinfo_get_uarch(uint32_t index) {
 	if (!cpuinfo_is_initialized) {
 		cpuinfo_log_fatal("cpuinfo_get_%s called before cpuinfo is initialized", "uarch");
 	}
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+		|| CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 		if CPUINFO_UNLIKELY(index >= cpuinfo_uarchs_count) {
 			return NULL;
 		}
@@ -175,7 +179,8 @@ uint32_t cpuinfo_get_uarchs_count(void) {
 	if (!cpuinfo_is_initialized) {
 		cpuinfo_log_fatal("cpuinfo_get_%s called before cpuinfo is initialized", "uarchs_count");
 	}
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+		|| CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 		return cpuinfo_uarchs_count;
 	#else
 		return 1;
@@ -351,7 +356,8 @@ uint32_t CPUINFO_ABI cpuinfo_get_current_uarch_index(void) {
 	if CPUINFO_UNLIKELY(!cpuinfo_is_initialized) {
 		cpuinfo_log_fatal("cpuinfo_get_%s called before cpuinfo is initialized", "current_uarch_index");
 	}
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+		|| CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 		#ifdef __linux__
 			if (cpuinfo_linux_cpu_to_uarch_index_map == NULL) {
 				/* Special case: avoid syscall on systems with only a single type of cores */
@@ -373,7 +379,7 @@ uint32_t CPUINFO_ABI cpuinfo_get_current_uarch_index(void) {
 			return 0;
 		#endif
 	#else
-		/* Only ARM/ARM64 processors may include cores of different types in the same package. */
+		/* Only ARM/ARM64/RISCV processors may include cores of different types in the same package. */
 		return 0;
 	#endif
 }
@@ -382,7 +388,8 @@ uint32_t CPUINFO_ABI cpuinfo_get_current_uarch_index_with_default(uint32_t defau
 	if CPUINFO_UNLIKELY(!cpuinfo_is_initialized) {
 		cpuinfo_log_fatal("cpuinfo_get_%s called before cpuinfo is initialized", "current_uarch_index_with_default");
 	}
-	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+	#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 \
+		|| CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 		#ifdef __linux__
 			if (cpuinfo_linux_cpu_to_uarch_index_map == NULL) {
 				/* Special case: avoid syscall on systems with only a single type of cores */
@@ -404,7 +411,7 @@ uint32_t CPUINFO_ABI cpuinfo_get_current_uarch_index_with_default(uint32_t defau
 			return default_uarch_index;
 		#endif
 	#else
-		/* Only ARM/ARM64 processors may include cores of different types in the same package. */
+		/* Only ARM/ARM64/RISCV processors may include cores of different types in the same package. */
 		return 0;
 	#endif
 }

--- a/src/cpuinfo/internal-api.h
+++ b/src/cpuinfo/internal-api.h
@@ -35,7 +35,7 @@ extern CPUINFO_INTERNAL uint32_t cpuinfo_packages_count;
 extern CPUINFO_INTERNAL uint32_t cpuinfo_cache_count[cpuinfo_cache_level_max];
 extern CPUINFO_INTERNAL uint32_t cpuinfo_max_cache_size;
 
-#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 || CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 	extern CPUINFO_INTERNAL struct cpuinfo_uarch_info* cpuinfo_uarchs;
 	extern CPUINFO_INTERNAL uint32_t cpuinfo_uarchs_count;
 #else
@@ -59,6 +59,7 @@ CPUINFO_PRIVATE void cpuinfo_x86_linux_init(void);
 #endif
 CPUINFO_PRIVATE void cpuinfo_arm_mach_init(void);
 CPUINFO_PRIVATE void cpuinfo_arm_linux_init(void);
+CPUINFO_PRIVATE void cpuinfo_riscv_linux_init(void);
 CPUINFO_PRIVATE void cpuinfo_emscripten_init(void);
 
 CPUINFO_PRIVATE uint32_t cpuinfo_compute_max_cache_size(const struct cpuinfo_processor* processor);

--- a/src/init.c
+++ b/src/init.c
@@ -42,6 +42,12 @@ bool CPUINFO_ABI cpuinfo_initialize(void) {
 	#else
 		cpuinfo_log_error("operating system is not supported in cpuinfo");
 	#endif
+#elif CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	#if defined(__linux__)
+		pthread_once(&init_guard, &cpuinfo_riscv_linux_init);
+	#else
+		cpuinfo_log_error("operating system is not supported in cpuinfo");
+	#endif
 #elif CPUINFO_ARCH_ASMJS || CPUINFO_ARCH_WASM || CPUINFO_ARCH_WASMSIMD
 	#if defined(__EMSCRIPTEN_PTHREADS__)
 		pthread_once(&init_guard, &cpuinfo_emscripten_init);

--- a/src/linux/api.h
+++ b/src/linux/api.h
@@ -21,7 +21,8 @@
 #define CPUINFO_LINUX_FLAG_PACKAGE_CLUSTER    UINT32_C(0x00000400)
 #define CPUINFO_LINUX_FLAG_PROC_CPUINFO       UINT32_C(0x00000800)
 #define CPUINFO_LINUX_FLAG_VALID              UINT32_C(0x00001000)
-
+#define CPUINFO_LINUX_FLAG_CUR_FREQUENCY      UINT32_C(0x00002000)
+#define CPUINFO_LINUX_FLAG_CLUSTER_CLUSTER    UINT32_C(0x00004000)
 
 typedef bool (*cpuinfo_cpulist_callback)(uint32_t, uint32_t, void*);
 CPUINFO_INTERNAL bool cpuinfo_linux_parse_cpulist(const char* filename, cpuinfo_cpulist_callback callback, void* context);
@@ -33,6 +34,7 @@ CPUINFO_INTERNAL bool cpuinfo_linux_parse_multiline_file(const char* filename, s
 CPUINFO_INTERNAL uint32_t cpuinfo_linux_get_max_processors_count(void);
 CPUINFO_INTERNAL uint32_t cpuinfo_linux_get_max_possible_processor(uint32_t max_processors_count);
 CPUINFO_INTERNAL uint32_t cpuinfo_linux_get_max_present_processor(uint32_t max_processors_count);
+CPUINFO_INTERNAL uint32_t cpuinfo_linux_get_processor_cur_frequency(uint32_t processor);
 CPUINFO_INTERNAL uint32_t cpuinfo_linux_get_processor_min_frequency(uint32_t processor);
 CPUINFO_INTERNAL uint32_t cpuinfo_linux_get_processor_max_frequency(uint32_t processor);
 CPUINFO_INTERNAL bool cpuinfo_linux_get_processor_package_id(uint32_t processor, uint32_t package_id[restrict static 1]);
@@ -50,6 +52,21 @@ CPUINFO_INTERNAL bool cpuinfo_linux_detect_core_siblings(
 	cpuinfo_siblings_callback callback,
 	void* context);
 CPUINFO_INTERNAL bool cpuinfo_linux_detect_thread_siblings(
+	uint32_t max_processors_count,
+	uint32_t processor,
+	cpuinfo_siblings_callback callback,
+	void* context);
+CPUINFO_INTERNAL bool cpuinfo_linux_detect_cluster_cpus(
+	uint32_t max_processors_count,
+	uint32_t processor,
+	cpuinfo_siblings_callback callback,
+	void* context);
+CPUINFO_INTERNAL bool cpuinfo_linux_detect_core_cpus(
+	uint32_t max_processors_count,
+	uint32_t processor,
+	cpuinfo_siblings_callback callback,
+	void* context);
+CPUINFO_INTERNAL bool cpuinfo_linux_detect_package_cpus(
 	uint32_t max_processors_count,
 	uint32_t processor,
 	cpuinfo_siblings_callback callback,

--- a/src/linux/processors.c
+++ b/src/linux/processors.c
@@ -21,6 +21,7 @@
 #define KERNEL_MAX_FILENAME "/sys/devices/system/cpu/kernel_max"
 #define KERNEL_MAX_FILESIZE 32
 #define FREQUENCY_FILENAME_SIZE (sizeof("/sys/devices/system/cpu/cpu" STRINGIFY(UINT32_MAX) "/cpufreq/cpuinfo_max_freq"))
+#define CUR_FREQUENCY_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/cpufreq/cpuinfo_cur_freq"
 #define MAX_FREQUENCY_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/cpufreq/cpuinfo_max_freq"
 #define MIN_FREQUENCY_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/cpufreq/cpuinfo_min_freq"
 #define FREQUENCY_FILESIZE 32
@@ -31,8 +32,14 @@
 #define CORE_ID_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/topology/core_id"
 #define CORE_ID_FILESIZE 32
 
+#define CORE_CPUS_FILENAME_SIZE (sizeof("/sys/devices/system/cpu/cpu" STRINGIFY(UINT32_MAX) "/topology/core_cpus_list"))
+#define CORE_CPUS_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/topology/core_cpus_list"
 #define CORE_SIBLINGS_FILENAME_SIZE (sizeof("/sys/devices/system/cpu/cpu" STRINGIFY(UINT32_MAX) "/topology/core_siblings_list"))
 #define CORE_SIBLINGS_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/topology/core_siblings_list"
+#define CLUSTER_CPUS_FILENAME_SIZE (sizeof("/sys/devices/system/cpu/cpu" STRINGIFY(UINT32_MAX) "/topology/cluster_cpus_list"))
+#define CLUSTER_CPUS_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/topology/cluster_cpus_list"
+#define PACKAGE_CPUS_FILENAME_SIZE (sizeof("/sys/devices/system/cpu/cpu" STRINGIFY(UINT32_MAX) "/topology/package_cpus_list"))
+#define PACKAGE_CPUS_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/topology/package_cpus_list"
 #define THREAD_SIBLINGS_FILENAME_SIZE (sizeof("/sys/devices/system/cpu/cpu" STRINGIFY(UINT32_MAX) "/topology/thread_siblings_list"))
 #define THREAD_SIBLINGS_FILENAME_FORMAT "/sys/devices/system/cpu/cpu%" PRIu32 "/topology/thread_siblings_list"
 
@@ -122,6 +129,27 @@ uint32_t cpuinfo_linux_get_max_processors_count(void) {
 	} else {
 		cpuinfo_log_warning("using platform-default max processors count = %"PRIu32, default_max_processors_count);
 		return default_max_processors_count;
+	}
+}
+
+uint32_t cpuinfo_linux_get_processor_cur_frequency(uint32_t processor) {
+	char cur_frequency_filename[FREQUENCY_FILENAME_SIZE];
+	const int chars_formatted = snprintf(
+		cur_frequency_filename, FREQUENCY_FILENAME_SIZE, CUR_FREQUENCY_FILENAME_FORMAT, processor);
+	if ((unsigned int) chars_formatted >= FREQUENCY_FILENAME_SIZE) {
+		cpuinfo_log_warning("failed to format filename for current frequency of processor %"PRIu32, processor);
+		return 0;
+	}
+
+	uint32_t cur_frequency;
+	if (cpuinfo_linux_parse_small_file(cur_frequency_filename, FREQUENCY_FILESIZE, uint32_parser, &cur_frequency)) {
+		cpuinfo_log_debug("parsed currrent frequency value of %"PRIu32" KHz for logical processor %"PRIu32" from %s",
+			cur_frequency, processor, cur_frequency_filename);
+		return cur_frequency;
+	} else {
+		cpuinfo_log_warning("failed to parse current frequency for processor %"PRIu32" from %s",
+			processor, cur_frequency_filename);
+		return 0;
 	}
 }
 
@@ -285,8 +313,7 @@ static bool detect_processor_parser(uint32_t processor_list_start, uint32_t proc
 }
 
 bool cpuinfo_linux_detect_possible_processors(uint32_t max_processors_count,
-	uint32_t* processor0_flags, uint32_t processor_struct_size, uint32_t possible_flag)
-{
+	uint32_t* processor0_flags, uint32_t processor_struct_size, uint32_t possible_flag) {
 	struct detect_processors_context context = {
 		.max_processors_count = max_processors_count,
 		.processor0_flags = processor0_flags,
@@ -302,8 +329,7 @@ bool cpuinfo_linux_detect_possible_processors(uint32_t max_processors_count,
 }
 
 bool cpuinfo_linux_detect_present_processors(uint32_t max_processors_count,
-	uint32_t* processor0_flags, uint32_t processor_struct_size, uint32_t present_flag)
-{
+	uint32_t* processor0_flags, uint32_t processor_struct_size, uint32_t present_flag) {
 	struct detect_processors_context context = {
 		.max_processors_count = max_processors_count,
 		.processor0_flags = processor0_flags,
@@ -340,12 +366,41 @@ static bool siblings_parser(uint32_t sibling_list_start, uint32_t sibling_list_e
 	return context->callback(processor, sibling_list_start, sibling_list_end, context->callback_context);
 }
 
+bool cpuinfo_linux_detect_core_cpus(
+	uint32_t max_processors_count,
+	uint32_t processor,
+	cpuinfo_siblings_callback callback,
+	void* context) {
+	char core_cpus_filename[CORE_CPUS_FILENAME_SIZE];
+	const int chars_formatted = snprintf(
+		core_cpus_filename, CORE_CPUS_FILENAME_SIZE, CORE_CPUS_FILENAME_FORMAT, processor);
+	if ((unsigned int) chars_formatted >= CORE_CPUS_FILENAME_SIZE) {
+		cpuinfo_log_warning("failed to format filename for core cpus of processor %"PRIu32, processor);
+		return false;
+	}
+
+	struct siblings_context siblings_context = {
+		.group_name = "cpus",
+		.max_processors_count = max_processors_count,
+		.processor = processor,
+		.callback = callback,
+		.callback_context = context,
+	};
+	if (cpuinfo_linux_parse_cpulist(core_cpus_filename,
+		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context)) {
+		return true;
+	} else {
+		cpuinfo_log_info("failed to parse the list of core cpus for processor %"PRIu32" from %s",
+			processor, core_cpus_filename);
+		return false;
+	}
+}
+
 bool cpuinfo_linux_detect_core_siblings(
 	uint32_t max_processors_count,
 	uint32_t processor,
 	cpuinfo_siblings_callback callback,
-	void* context)
-{
+	void* context) {
 	char core_siblings_filename[CORE_SIBLINGS_FILENAME_SIZE];
 	const int chars_formatted = snprintf(
 		core_siblings_filename, CORE_SIBLINGS_FILENAME_SIZE, CORE_SIBLINGS_FILENAME_FORMAT, processor);
@@ -362,8 +417,7 @@ bool cpuinfo_linux_detect_core_siblings(
 		.callback_context = context,
 	};
 	if (cpuinfo_linux_parse_cpulist(core_siblings_filename,
-		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context))
-	{
+		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context)) {
 		return true;
 	} else {
 		cpuinfo_log_info("failed to parse the list of core siblings for processor %"PRIu32" from %s",
@@ -376,8 +430,7 @@ bool cpuinfo_linux_detect_thread_siblings(
 	uint32_t max_processors_count,
 	uint32_t processor,
 	cpuinfo_siblings_callback callback,
-	void* context)
-{
+	void* context) {
 	char thread_siblings_filename[THREAD_SIBLINGS_FILENAME_SIZE];
 	const int chars_formatted = snprintf(
 		thread_siblings_filename, THREAD_SIBLINGS_FILENAME_SIZE, THREAD_SIBLINGS_FILENAME_FORMAT, processor);
@@ -394,8 +447,7 @@ bool cpuinfo_linux_detect_thread_siblings(
 		.callback_context = context,
 	};
 	if (cpuinfo_linux_parse_cpulist(thread_siblings_filename,
-		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context))
-	{
+		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context)) {
 		return true;
 	} else {
 		cpuinfo_log_info("failed to parse the list of thread siblings for processor %"PRIu32" from %s",
@@ -404,3 +456,62 @@ bool cpuinfo_linux_detect_thread_siblings(
 	}
 }
 
+bool cpuinfo_linux_detect_cluster_cpus(
+	uint32_t max_processors_count,
+	uint32_t processor,
+	cpuinfo_siblings_callback callback,
+	void* context) {
+	char cluster_cpus_filename[CLUSTER_CPUS_FILENAME_SIZE];
+	const int chars_formatted = snprintf(
+		cluster_cpus_filename, CLUSTER_CPUS_FILENAME_SIZE, CLUSTER_CPUS_FILENAME_FORMAT, processor);
+	if ((unsigned int) chars_formatted >= CLUSTER_CPUS_FILENAME_SIZE) {
+		cpuinfo_log_warning("failed to format filename for cluster cpus of processor %"PRIu32, processor);
+		return false;
+	}
+
+	struct siblings_context siblings_context = {
+		.group_name = "cluster",
+		.max_processors_count = max_processors_count,
+		.processor = processor,
+		.callback = callback,
+		.callback_context = context,
+	};
+	if (cpuinfo_linux_parse_cpulist(cluster_cpus_filename,
+		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context)) {
+		return true;
+	} else {
+		cpuinfo_log_info("failed to parse the list of cluster cpus for processor %"PRIu32" from %s",
+			processor, cluster_cpus_filename);
+		return false;
+	}
+}
+
+bool cpuinfo_linux_detect_package_cpus(
+	uint32_t max_processors_count,
+	uint32_t processor,
+	cpuinfo_siblings_callback callback,
+	void* context) {
+	char package_cpus_filename[PACKAGE_CPUS_FILENAME_SIZE];
+	const int chars_formatted = snprintf(
+		package_cpus_filename, PACKAGE_CPUS_FILENAME_SIZE, PACKAGE_CPUS_FILENAME_FORMAT, processor);
+	if ((unsigned int) chars_formatted >= PACKAGE_CPUS_FILENAME_SIZE) {
+		cpuinfo_log_warning("failed to format filename for package cpus of processor %"PRIu32, processor);
+		return false;
+	}
+
+	struct siblings_context siblings_context = {
+		.group_name = "package",
+		.max_processors_count = max_processors_count,
+		.processor = processor,
+		.callback = callback,
+		.callback_context = context,
+	};
+	if (cpuinfo_linux_parse_cpulist(package_cpus_filename,
+		(cpuinfo_cpulist_callback) siblings_parser, &siblings_context)) {
+		return true;
+	} else {
+		cpuinfo_log_info("failed to parse the list of package cpus for processor %"PRIu32" from %s",
+			processor, package_cpus_filename);
+		return false;
+	}
+}

--- a/src/riscv/api.h
+++ b/src/riscv/api.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdint.h>
+
+#include <cpuinfo.h>
+#include <cpuinfo/common.h>
+
+/* RISC-V Vendor IDs. */
+enum cpuinfo_riscv_chipset_vendor {
+	cpuinfo_riscv_chipset_vendor_unknown = 0,
+	cpuinfo_riscv_chipset_sifive = 0x489,
+	cpuinfo_riscv_chipset_vendor_max,
+};
+
+/* RISC-V Architecture IDs. */
+enum cpuinfo_riscv_chipset_arch {
+	cpuinfo_riscv_chipset_arch_unknown = 0,
+	cpuinfo_riscv_chipset_arch_max,
+};
+
+/* RISC-V Implementation IDs. */
+enum cpuinfo_riscv_chipset_impl {
+	cpuinfo_riscv_chipset_impl_unknown = 0,
+	cpuinfo_riscv_chipset_impl_max,
+};
+
+/**
+ * Decodes the vendor and micro-architecture based on the provided input
+ * parameters, regardless of underlying operating system.
+ *
+ * @param[vendor_id]: The 'mvendorid' as described by the RISC-V Manual.
+ * @param[arch_id]: The 'marchid' as described by the RISC-V Manual.
+ * @param[imp_id]: The 'mimplid' as described by the RISC-V Manual.
+ * @param[vendor] - Reference to the cpuinfo_vendor to populate.
+ * @param[uarch] - Reference to the cpuinfo_uarch to populate.
+ */
+CPUINFO_INTERNAL void cpuinfo_riscv_decode_vendor_uarch(
+		uint32_t vendor_id,
+		uint32_t arch_id,
+		uint32_t imp_id,
+		enum cpuinfo_vendor vendor[restrict static 1],
+		enum cpuinfo_uarch uarch[restrict static 1]);

--- a/src/riscv/linux/api.h
+++ b/src/riscv/linux/api.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cpuinfo.h>
+#include <cpuinfo/common.h>
+
+/**
+ * Definition of a RISC-V Linux processor. It is composed of the base processor
+ * definition in "include/cpuinfo.h" and flags specific to RISC-V Linux
+ * implementations.
+ */
+struct cpuinfo_riscv_linux_processor {
+	/* Public ABI cpuinfo structures. */
+	struct cpuinfo_processor processor;
+	struct cpuinfo_core core;
+	struct cpuinfo_cluster cluster;
+	struct cpuinfo_package package;
+
+	/**
+	 * Linux-specific flags for the logical processor:
+	 * - Bit field that can be masked with CPUINFO_LINUX_FLAG_*.
+	 */
+	uint32_t flags;
+
+	/**
+	 * Minimum processor ID on the cluster which includes this logical processor.
+	 * This value can serve as an ID for the cluster of logical processors: it is the
+	 * same for all logical processors on the same package.
+	 */
+	uint32_t cluster_leader_id;
+
+	/**
+	 * Minimum processor ID on the core which includes this logical processor.
+	 * This value can serve as an ID for the core of logical processors: it
+	 * is the same for all logical processors on the same core.
+	 */
+	uint32_t core_leader_id;
+
+	/**
+	 * Minimum processor ID on the package which includes this logical processor.
+	 * This value can serve as an ID for the package of logical processors: it
+	 * is the same for all logical processors on the same package.
+	 */
+	uint32_t package_leader_id;
+};
+
+/**
+ * Reads AT_HWCAP from `getauxval` and populates the cpuinfo_riscv_isa
+ * structure.
+ *
+ * @param[isa] - Reference to cpuinfo_riscv_isa structure to populate.
+ */
+CPUINFO_INTERNAL void cpuinfo_riscv_linux_decode_isa_from_hwcap(
+	struct cpuinfo_riscv_isa isa[restrict static 1]);
+
+/**
+ * Reads `sys_riscv_hwprobe` and determines the processor vendor and
+ * micro-architecture.
+ *
+ * @param[processor] - The Linux ID of the target processor.
+ * @param[vendor] - Reference to the cpuinfo_vendor to populate.
+ * @param[uarch] - Reference to the cpuinfo_uarch to populate.
+ */
+CPUINFO_INTERNAL void cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
+	uint32_t processor,
+	enum cpuinfo_vendor vendor[restrict static 1],
+	enum cpuinfo_uarch uarch[restrict static 1]);
+
+/* Used to determine which uarch is associated with the current thread. */
+extern CPUINFO_INTERNAL const uint32_t* cpuinfo_linux_cpu_to_uarch_index_map;

--- a/src/riscv/linux/init.c
+++ b/src/riscv/linux/init.c
@@ -1,0 +1,620 @@
+#include <string.h>
+
+#include <cpuinfo/internal-api.h>
+#include <cpuinfo/log.h>
+#include <linux/api.h>
+#include <riscv/linux/api.h>
+
+/* ISA structure to hold supported extensions. */
+struct cpuinfo_riscv_isa cpuinfo_isa;
+
+/* Helper function to bitmask flags and ensure operator precedence. */
+static inline bool bitmask_all(uint32_t flags, uint32_t mask) {
+  return (flags & mask) == mask;
+}
+
+static int compare_riscv_linux_processors(const void* a, const void* b) {
+	/**
+	 * For our purposes, it is only relevant that the list is sorted by
+	 * micro-architecture, so the nature of ordering is irrelevant.
+	 */
+	return ((const struct cpuinfo_riscv_linux_processor*)a)->core.uarch
+			- ((const struct cpuinfo_riscv_linux_processor*)b)->core.uarch;
+}
+
+/**
+ * Parses the core cpus list for each processor. This function is called once
+ * per-processor, with the IDs of all other processors in the core list.
+ *
+ * The 'processor_[start|count]' are populated in the processor's 'core'
+ * attribute, with 'start' being the smallest ID in the core list.
+ *
+ * The 'core_leader_id' of each processor is set to the smallest ID in it's
+ * cluster CPU list.
+ *
+ * Precondition: The element in the 'processors' list must be initialized with
+ * their 'core_leader_id' to their index in the list.
+
+ * E.g. processors[0].core_leader_id = 0.
+ */
+static bool core_cpus_parser(uint32_t processor,
+			     uint32_t core_cpus_start,
+			     uint32_t core_cpus_end,
+			     struct cpuinfo_riscv_linux_processor* processors) {
+	uint32_t processor_start = UINT32_MAX;
+	uint32_t processor_count = 0;
+
+	/* If the processor already has a leader, use it. */
+	if (bitmask_all(processors[processor].flags, CPUINFO_LINUX_FLAG_CORE_CLUSTER)) {
+		processor_start = processors[processor].core_leader_id;
+	}
+
+	for (size_t core_cpu = core_cpus_start; core_cpu < core_cpus_end; core_cpu++) {
+		if (!bitmask_all(processors[core_cpu].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		/**
+		 * The first valid processor observed is the smallest ID in the
+		 * list that attaches to this core.
+		 */
+		if (processor_start == UINT32_MAX) {
+			processor_start = core_cpu;
+		}
+		processors[core_cpu].core_leader_id = processor_start;
+		processor_count++;
+	}
+	/**
+	 * If the cluster flag has not been set, assign the processor start. If
+	 * it has been set, only apply the processor start if it's less than the
+	 * held value. This can happen if the callback is invoked twice:
+	 *
+	 * e.g. core_cpu_list=1,10-12
+	 */
+	if (!bitmask_all(processors[processor].flags, CPUINFO_LINUX_FLAG_CORE_CLUSTER)
+	    || processors[processor].core.processor_start > processor_start) {
+		processors[processor].core.processor_start = processor_start;
+		processors[processor].core_leader_id = processor_start;
+	}
+	processors[processor].core.processor_count += processor_count;
+	processors[processor].flags |= CPUINFO_LINUX_FLAG_CORE_CLUSTER;
+	/* The parser has failed only if no processors were found. */
+	return processor_count != 0;
+}
+
+/**
+ * Parses the cluster cpu list for each processor. This function is called once
+ * per-processor, with the IDs of all other processors in the cluster.
+ *
+ * The 'cluster_leader_id' of each processor is set to the smallest ID in it's
+ * cluster CPU list.
+ *
+ * Precondition: The element in the 'processors' list must be initialized with
+ * their 'cluster_leader_id' to their index in the list.
+ * E.g. processors[0].cluster_leader_id = 0.
+ */
+static bool cluster_cpus_parser(uint32_t processor,
+				uint32_t cluster_cpus_start,
+				uint32_t cluster_cpus_end,
+				struct cpuinfo_riscv_linux_processor* processors) {
+	uint32_t processor_start = UINT32_MAX;
+	uint32_t processor_count = 0;
+	uint32_t core_count = 0;
+
+	/* If the processor already has a leader, use it. */
+	if (bitmask_all(processors[processor].flags, CPUINFO_LINUX_FLAG_CLUSTER_CLUSTER)) {
+		processor_start = processors[processor].cluster_leader_id;
+	}
+
+	for (size_t cluster_cpu = cluster_cpus_start; cluster_cpu < cluster_cpus_end; cluster_cpu++) {
+		if (!bitmask_all(processors[cluster_cpu].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		/**
+		 * The first valid processor observed is the smallest ID in the
+		 * list that attaches to this core.
+		 */
+		if (processor_start == UINT32_MAX) {
+			processor_start = cluster_cpu;
+		}
+		processors[cluster_cpu].cluster_leader_id = processor_start;
+		processor_count++;
+		/**
+		 * A processor should only represent it's core if it is the
+		 * assigned leader of that core.
+		 */
+		if (processors[cluster_cpu].core_leader_id == cluster_cpu) {
+			core_count++;
+		}
+	}
+	/**
+	 * If the cluster flag has not been set, assign the processor start. If
+	 * it has been set, only apply the processor start if it's less than the
+	 * held value. This can happen if the callback is invoked twice:
+	 *
+	 * e.g. cluster_cpus_list=1,10-12
+	 */
+	if (!bitmask_all(processors[processor].flags, CPUINFO_LINUX_FLAG_CLUSTER_CLUSTER)
+	    || processors[processor].cluster.processor_start > processor_start) {
+		processors[processor].cluster.processor_start = processor_start;
+		processors[processor].cluster.core_start = processor_start;
+		processors[processor].cluster.cluster_id = processor_start;
+		processors[processor].cluster_leader_id = processor_start;
+	}
+	processors[processor].cluster.processor_count += processor_count;
+	processors[processor].cluster.core_count += core_count;
+	processors[processor].flags |= CPUINFO_LINUX_FLAG_CLUSTER_CLUSTER;
+	return true;
+}
+
+/**
+ * Parses the package cpus list for each processor. This function is called once
+ * per-processor, with the IDs of all other processors in the package list.
+ *
+ * The 'processor_[start|count]' are populated in the processor's 'package'
+ * attribute, with 'start' being the smallest ID in the package list.
+ *
+ * The 'package_leader_id' of each processor is set to the smallest ID in it's
+ * cluster CPU list.
+ *
+ * Precondition: The element in the 'processors' list must be initialized with
+ * their 'package_leader_id' to their index in the list.
+ * E.g. processors[0].package_leader_id = 0.
+ */
+static bool package_cpus_parser(uint32_t processor,
+			     uint32_t package_cpus_start,
+			     uint32_t package_cpus_end,
+			     struct cpuinfo_riscv_linux_processor* processors) {
+	uint32_t processor_start = UINT32_MAX;
+	uint32_t processor_count = 0;
+	uint32_t cluster_count = 0;
+	uint32_t core_count = 0;
+
+	/* If the processor already has a leader, use it. */
+	if (bitmask_all(processors[processor].flags, CPUINFO_LINUX_FLAG_PACKAGE_CLUSTER)) {
+		processor_start = processors[processor].package_leader_id;
+	}
+
+	for (size_t package_cpu = package_cpus_start; package_cpu < package_cpus_end; package_cpu++) {
+		if (!bitmask_all(processors[package_cpu].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		/**
+		 * The first valid processor observed is the smallest ID in the
+		 * list that attaches to this package.
+		 */
+		if (processor_start == UINT32_MAX) {
+			processor_start = package_cpu;
+		}
+		processors[package_cpu].package_leader_id = processor_start;
+		processor_count++;
+		/**
+		 * A processor should only represent it's core if it is the
+		 * assigned leader of that core, and similarly for it's cluster.
+		 */
+		if (processors[package_cpu].cluster_leader_id == package_cpu) {
+			cluster_count++;
+		}
+		if (processors[package_cpu].core_leader_id == package_cpu) {
+			core_count++;
+		}
+	}
+	/**
+	 * If the cluster flag has not been set, assign the processor start. If
+	 * it has been set, only apply the processor start if it's less than the
+	 * held value. This can happen if the callback is invoked twice:
+	 *
+	 * e.g. package_cpus_list=1,10-12
+	 */
+	if (!bitmask_all(processors[processor].flags, CPUINFO_LINUX_FLAG_PACKAGE_CLUSTER)
+	    || processors[processor].package.processor_start > processor_start) {
+		processors[processor].package.processor_start = processor_start;
+		processors[processor].package.cluster_start = processor_start;
+		processors[processor].package.core_start = processor_start;
+		processors[processor].package_leader_id = processor_start;
+	}
+	processors[processor].package.processor_count += processor_count;
+	processors[processor].package.cluster_count += cluster_count;
+	processors[processor].package.core_count += core_count;
+	processors[processor].flags |= CPUINFO_LINUX_FLAG_PACKAGE_CLUSTER;
+	return true;
+}
+
+/* Initialization for the RISC-V Linux system. */
+void cpuinfo_riscv_linux_init(void) {
+	struct cpuinfo_riscv_linux_processor* riscv_linux_processors = NULL;
+	struct cpuinfo_processor* processors = NULL;
+	struct cpuinfo_package* packages = NULL;
+	struct cpuinfo_cluster* clusters = NULL;
+	struct cpuinfo_core* cores = NULL;
+	struct cpuinfo_uarch_info* uarchs = NULL;
+	const struct cpuinfo_processor** linux_cpu_to_processor_map = NULL;
+	const struct cpuinfo_core** linux_cpu_to_core_map = NULL;
+	uint32_t* linux_cpu_to_uarch_index_map = NULL;
+
+	/**
+	 * The interesting set of processors are the number of 'present'
+	 * processors on the system. There may be more 'possible' processors, but
+	 * processor information cannot be gathered on non-present processors.
+	 *
+	 * Note: For SoCs, it is largely the case that all processors are known
+	 * at boot and no processors are hotplugged at runtime, so the
+	 * 'present' and 'possible' list is often the same.
+	 *
+	 * Note: This computes the maximum processor ID of the 'present'
+	 * processors. It is not a count of the number of processors on the
+	 * system.
+	 */
+	const size_t max_processor_id = 1 +
+		cpuinfo_linux_get_max_present_processor(
+				cpuinfo_linux_get_max_processors_count());
+	if (max_processor_id == 0) {
+		cpuinfo_log_error("failed to discover any processors");
+		return;
+	}
+
+	/**
+	 * Allocate space to store all processor information. This array is
+	 * sized to the max processor ID as opposed to the number of 'present'
+	 * processors, to leverage pointer math in the common utility functions.
+	 */
+	riscv_linux_processors = calloc(max_processor_id,
+					sizeof(struct cpuinfo_riscv_linux_processor));
+	if (riscv_linux_processors == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu processors.",
+			max_processor_id * sizeof(struct cpuinfo_riscv_linux_processor),
+			max_processor_id);
+		goto cleanup;
+        }
+
+	/**
+	 * Attempt to detect all processors and apply the corresponding flag to
+	 * each processor struct that we find.
+	 */
+	if (!cpuinfo_linux_detect_present_processors(max_processor_id,
+						     &riscv_linux_processors->flags,
+						     sizeof(struct cpuinfo_riscv_linux_processor),
+						     CPUINFO_LINUX_FLAG_PRESENT | CPUINFO_LINUX_FLAG_VALID)) {
+		cpuinfo_log_error("failed to detect present processors");
+		goto cleanup;
+	}
+
+        /* Populate processor information. */
+        for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+                }
+                /* TODO: Determine if an 'smt_id' is available. */
+                riscv_linux_processors[processor].processor.linux_id = processor;
+        }
+
+	/* Populate core information. */
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+
+		/* Populate processor start and count information. */
+		if (!cpuinfo_linux_detect_core_cpus(
+				max_processor_id,
+				processor,
+				(cpuinfo_siblings_callback) core_cpus_parser,
+				riscv_linux_processors)) {
+			cpuinfo_log_error("failed to detect core cpus for processor %zu.", processor);
+			goto cleanup;
+		}
+
+		/* Populate core ID information. */
+		if (cpuinfo_linux_get_processor_core_id(
+				processor,
+				&riscv_linux_processors[processor].core.core_id)) {
+			riscv_linux_processors[processor].flags |= CPUINFO_LINUX_FLAG_CORE_ID;
+		}
+
+		/**
+		 * Populate the vendor and uarch of this core from this
+		 * processor. When the final 'cores' list is constructed, only
+		 * the values from the core leader will be honored.
+		 */
+		cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
+				processor,
+				&riscv_linux_processors[processor].core.vendor,
+				&riscv_linux_processors[processor].core.uarch);
+
+		/* Populate frequency information of this core. */
+		uint32_t frequency = cpuinfo_linux_get_processor_cur_frequency(processor);
+		if (frequency != 0) {
+			riscv_linux_processors[processor].core.frequency = frequency;
+			riscv_linux_processors[processor].flags |= CPUINFO_LINUX_FLAG_CUR_FREQUENCY;
+		}
+	}
+
+	/* Populate cluster information. */
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		if (!cpuinfo_linux_detect_cluster_cpus(
+				max_processor_id,
+				processor,
+				(cpuinfo_siblings_callback) cluster_cpus_parser,
+				riscv_linux_processors)) {
+			cpuinfo_log_warning("failed to detect cluster cpus for processor %zu.", processor);
+			goto cleanup;
+		}
+
+		/**
+		 * Populate the vendor, uarch and frequency of this cluster from
+		 * this logical processor. When the 'clusters' list is constructed,
+		 * only the values from the cluster leader will be honored.
+		 */
+		riscv_linux_processors[processor].cluster.vendor =
+				riscv_linux_processors[processor].core.vendor;
+		riscv_linux_processors[processor].cluster.uarch =
+				riscv_linux_processors[processor].core.uarch;
+		riscv_linux_processors[processor].cluster.frequency =
+				riscv_linux_processors[processor].core.frequency;
+	}
+
+	/* Populate package information. */
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		if (!cpuinfo_linux_detect_package_cpus(
+				max_processor_id,
+				processor,
+				(cpuinfo_siblings_callback) package_cpus_parser,
+				riscv_linux_processors)) {
+			cpuinfo_log_warning("failed to detect package cpus for processor %zu.", processor);
+			goto cleanup;
+		}
+	}
+
+	/* Populate ISA structure with hwcap information. */
+	cpuinfo_riscv_linux_decode_isa_from_hwcap(&cpuinfo_isa);
+
+	/**
+	 * To efficiently compute the number of unique micro-architectures
+	 * present on the system, sort the processor list by micro-architecture
+	 * and then scan through the list to count the differences.
+	 *
+	 * Ensure this is done at the end of composing the processor list - the
+	 * parsing functions assume that the position of the processor in the
+	 * list matches it's Linux ID, which this sorting operation breaks.
+	 */
+	qsort(riscv_linux_processors,
+	      max_processor_id,
+	      sizeof(struct cpuinfo_riscv_linux_processor),
+	      compare_riscv_linux_processors);
+
+	/**
+	 * Determine the number of *valid* detected processors, cores,
+	 * clusters, packages and uarchs in the list.
+	 */
+	size_t valid_processors_count = 0;
+	size_t valid_cores_count = 0;
+	size_t valid_clusters_count = 0;
+	size_t valid_packages_count = 0;
+	size_t valid_uarchs_count = 0;
+	enum cpuinfo_uarch last_uarch = cpuinfo_uarch_unknown;
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+
+		/**
+		 * All comparisons to the leader id values MUST be done against
+		 * the 'linux_id' as opposed to 'processor'. The sort function
+		 * above no longer allows us to make the assumption that these
+		 * two values are the same.
+		 */
+		uint32_t linux_id = riscv_linux_processors[processor].processor.linux_id;
+
+		valid_processors_count++;
+		if (riscv_linux_processors[processor].core_leader_id == linux_id) {
+			valid_cores_count++;
+		}
+		if (riscv_linux_processors[processor].cluster_leader_id == linux_id) {
+			valid_clusters_count++;
+		}
+		if (riscv_linux_processors[processor].package_leader_id == linux_id) {
+			valid_packages_count++;
+		}
+		/**
+		 * As we've sorted by micro-architecture, when the uarch differs
+		 * between two entries, a unique uarch has been observed.
+		 */
+		if (last_uarch != riscv_linux_processors[processor].core.uarch
+			|| valid_uarchs_count == 0) {
+			valid_uarchs_count++;
+			last_uarch = riscv_linux_processors[processor].core.uarch;
+		}
+	}
+
+	/* Allocate and populate final public ABI structures. */
+	processors = calloc(valid_processors_count,
+			    sizeof(struct cpuinfo_processor));
+	if (processors == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu processors.",
+			valid_processors_count * sizeof(struct cpuinfo_processor),
+			valid_processors_count);
+		goto cleanup;
+	}
+
+	cores = calloc(valid_cores_count,
+			    sizeof(struct cpuinfo_core));
+	if (cores == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu cores.",
+			valid_cores_count * sizeof(struct cpuinfo_core),
+			valid_cores_count);
+		goto cleanup;
+	}
+
+	clusters = calloc(valid_clusters_count,
+			    sizeof(struct cpuinfo_cluster));
+	if (clusters == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu clusters.",
+			valid_clusters_count * sizeof(struct cpuinfo_cluster),
+			valid_clusters_count);
+		goto cleanup;
+	}
+
+	packages = calloc(valid_packages_count,
+			    sizeof(struct cpuinfo_package));
+	if (packages == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu packages.",
+			valid_packages_count * sizeof(struct cpuinfo_package),
+			valid_packages_count);
+		goto cleanup;
+	}
+
+	uarchs = calloc(valid_uarchs_count, sizeof(struct cpuinfo_uarch_info));
+	if (uarchs == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu packages.",
+			valid_uarchs_count * sizeof(struct cpuinfo_uarch_info),
+			valid_uarchs_count);
+		goto cleanup;
+	}
+
+	linux_cpu_to_processor_map = calloc(max_processor_id,
+					    sizeof(struct cpuinfo_processor*));
+	if (linux_cpu_to_processor_map == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu processor map.",
+				  max_processor_id * sizeof(struct cpuinfo_processor*),
+				  max_processor_id);
+		goto cleanup;
+	}
+
+	linux_cpu_to_core_map = calloc(max_processor_id,
+				       sizeof(struct cpuinfo_core*));
+	if (linux_cpu_to_core_map == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu core map.",
+				  max_processor_id * sizeof(struct cpuinfo_core*),
+				  max_processor_id);
+		goto cleanup;
+	}
+
+	linux_cpu_to_uarch_index_map = calloc(max_processor_id,
+					      sizeof(struct cpuinfo_uarch_info*));
+	if (linux_cpu_to_uarch_index_map == NULL) {
+		cpuinfo_log_error("failed to allocate %zu bytes for %zu uarch map.",
+				  max_processor_id * sizeof(struct cpuinfo_uarch_info*),
+				  max_processor_id);
+		goto cleanup;
+	}
+
+	/* Transfer contents of processor list to ABI structures. */
+	size_t valid_processors_index = 0;
+	size_t valid_cores_index = 0;
+	size_t valid_clusters_index = 0;
+	size_t valid_packages_index = 0;
+	size_t valid_uarchs_index = 0;
+	last_uarch = cpuinfo_uarch_unknown;
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+
+		/**
+		 * All comparisons to the leader id values MUST be done against
+		 * the 'linux_id' as opposed to 'processor'. The sort function
+		 * above no longer allows us to make the assumption that these
+		 * two values are the same.
+		 */
+		uint32_t linux_id = riscv_linux_processors[processor].processor.linux_id;
+
+		/* Create uarch entry if this uarch has not been seen before. */
+		if (last_uarch != riscv_linux_processors[processor].core.uarch
+		    || valid_uarchs_index == 0) {
+			uarchs[valid_uarchs_index++].uarch =
+					riscv_linux_processors[processor].core.uarch;
+			last_uarch = riscv_linux_processors[processor].core.uarch;
+		}
+
+		/* Copy cpuinfo_processor information. */
+		memcpy(&processors[valid_processors_index++],
+		       &riscv_linux_processors[processor].processor,
+			sizeof(struct cpuinfo_processor));
+
+		/* Update uarch processor count. */
+		uarchs[valid_uarchs_index - 1].processor_count++;
+
+		/* Copy cpuinfo_core information, if this is the leader. */
+		if (riscv_linux_processors[processor].core_leader_id == linux_id) {
+			memcpy(&cores[valid_cores_index++],
+			       &riscv_linux_processors[processor].core,
+			       sizeof(struct cpuinfo_core));
+			/* Update uarch core count. */
+			uarchs[valid_uarchs_index - 1].core_count++;
+		}
+
+		/* Copy cpuinfo_cluster information, if this is the leader. */
+		if (riscv_linux_processors[processor].cluster_leader_id == linux_id) {
+			memcpy(&clusters[valid_clusters_index++],
+			       &riscv_linux_processors[processor].cluster,
+			       sizeof(struct cpuinfo_cluster));
+		}
+
+		/* Copy cpuinfo_package information, if this is the leader. */
+		if (riscv_linux_processors[processor].package_leader_id == linux_id) {
+			memcpy(&packages[valid_packages_index++],
+			       &riscv_linux_processors[processor].package,
+			       sizeof(struct cpuinfo_package));
+		}
+
+		/* Commit pointers on the final structures. */
+		processors[valid_processors_index - 1].core = &cores[valid_cores_index - 1];
+		processors[valid_processors_index - 1].cluster = &clusters[valid_clusters_index - 1];
+		processors[valid_processors_index - 1].package = &packages[valid_packages_index - 1];
+
+		cores[valid_cores_index - 1].cluster = &clusters[valid_clusters_index - 1];
+		cores[valid_cores_index - 1].package = &packages[valid_packages_index - 1];
+
+		clusters[valid_clusters_index - 1].package = &packages[valid_packages_index - 1];
+
+		linux_cpu_to_processor_map[linux_id] = &processors[valid_processors_index - 1];
+		linux_cpu_to_core_map[linux_id] = &cores[valid_cores_index - 1];
+		linux_cpu_to_uarch_index_map[linux_id] = valid_uarchs_index - 1;
+	}
+
+	/* Commit */
+	cpuinfo_processors = processors;
+	cpuinfo_processors_count = valid_processors_count;
+	cpuinfo_cores = cores;
+	cpuinfo_cores_count = valid_cores_count;
+	cpuinfo_clusters = clusters;
+	cpuinfo_clusters_count = valid_clusters_count;
+	cpuinfo_packages = packages;
+	cpuinfo_packages_count = valid_packages_count;
+	cpuinfo_uarchs = uarchs;
+	cpuinfo_uarchs_count = valid_uarchs_count;
+
+	cpuinfo_linux_cpu_max = max_processor_id;
+	cpuinfo_linux_cpu_to_processor_map = linux_cpu_to_processor_map;
+	cpuinfo_linux_cpu_to_core_map = linux_cpu_to_core_map;
+	cpuinfo_linux_cpu_to_uarch_index_map = linux_cpu_to_uarch_index_map;
+
+	__sync_synchronize();
+
+	cpuinfo_is_initialized = true;
+
+	/* Mark all public structures NULL to prevent cleanup from erasing them. */
+	processors = NULL;
+	cores = NULL;
+	clusters = NULL;
+	packages = NULL;
+	uarchs = NULL;
+	linux_cpu_to_processor_map = NULL;
+	linux_cpu_to_core_map = NULL;
+	linux_cpu_to_uarch_index_map = NULL;
+cleanup:
+	free(riscv_linux_processors);
+	free(processors);
+	free(cores);
+	free(clusters);
+	free(packages);
+	free(uarchs);
+	free(linux_cpu_to_processor_map);
+	free(linux_cpu_to_core_map);
+	free(linux_cpu_to_uarch_index_map);
+}

--- a/src/riscv/linux/riscv-hw.c
+++ b/src/riscv/linux/riscv-hw.c
@@ -1,0 +1,62 @@
+#include <sys/hwprobe.h>
+#include <sched.h>
+
+#include <cpuinfo/log.h>
+#include <riscv/api.h>
+#include <riscv/linux/api.h>
+
+void cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
+		uint32_t processor,
+		enum cpuinfo_vendor vendor[restrict static 1],
+		enum cpuinfo_uarch uarch[restrict static 1]) {
+	struct riscv_hwprobe pairs[] = {
+		{ .key = RISCV_HWPROBE_KEY_MVENDORID, },
+		{ .key = RISCV_HWPROBE_KEY_MARCHID, },
+		{ .key = RISCV_HWPROBE_KEY_MIMPID, },
+	};
+	const size_t pairs_count = sizeof(pairs) / sizeof(struct riscv_hwprobe);
+
+	/* In case of failure, report unknown. */
+	*vendor = cpuinfo_vendor_unknown;
+	*uarch = cpuinfo_uarch_unknown;
+
+	/* Create a CPU set with this processor flagged. */
+	const size_t cpu_set_size = processor + 1;
+	cpu_set_t* cpu_set = CPU_ALLOC(cpu_set_size);
+	CPU_SET(processor, cpu_set);
+
+	/* Request all available information from hwprobe. */
+	int ret = __riscv_hwprobe(pairs, pairs_count,
+                                  cpu_set_size, (unsigned long*)cpu_set,
+                                  0 /* flags */);
+	if (ret < 0) {
+		cpuinfo_log_warning("failed to get hwprobe information, err: %d", ret);
+		return;
+	}
+
+	/**
+	 * The syscall may not have populated all requested keys, loop through
+	 * the list and store the values that were discovered.
+	 */
+	uint32_t vendor_id = 0;
+	uint32_t arch_id = 0;
+	uint32_t imp_id = 0;
+	for (size_t pair = 0; pair < pairs_count; pair++) {
+		switch (pairs[pair].key) {
+			case RISCV_HWPROBE_KEY_MVENDORID:
+				vendor_id = pairs[pair].value;
+				break;
+			case RISCV_HWPROBE_KEY_MARCHID:
+				arch_id = pairs[pair].value;
+				break;
+			case RISCV_HWPROBE_KEY_MIMPID:
+				imp_id = pairs[pair].value;
+				break;
+			default:
+				/* The key value may be -1 if unsupported. */
+				break;
+		}
+	}
+	cpuinfo_riscv_decode_vendor_uarch(vendor_id, arch_id, imp_id,
+					  vendor, uarch);
+}

--- a/src/riscv/linux/riscv-isa.c
+++ b/src/riscv/linux/riscv-isa.c
@@ -1,0 +1,44 @@
+#include <string.h>
+#include <sys/auxv.h>
+
+#include <riscv/linux/api.h>
+
+/**
+ * arch/riscv/include/uapi/asm/hwcap.h
+ *
+ * This must be kept in sync with the upstream kernel header.
+ */
+#define COMPAT_HWCAP_ISA_I	(1 << ('I' - 'A'))
+#define COMPAT_HWCAP_ISA_M	(1 << ('M' - 'A'))
+#define COMPAT_HWCAP_ISA_A	(1 << ('A' - 'A'))
+#define COMPAT_HWCAP_ISA_F	(1 << ('F' - 'A'))
+#define COMPAT_HWCAP_ISA_D	(1 << ('D' - 'A'))
+#define COMPAT_HWCAP_ISA_C	(1 << ('C' - 'A'))
+#define COMPAT_HWCAP_ISA_V	(1 << ('V' - 'A'))
+
+void cpuinfo_riscv_linux_decode_isa_from_hwcap(
+		struct cpuinfo_riscv_isa isa[restrict static 1]) {
+	const unsigned long hwcap = getauxval(AT_HWCAP);
+
+	if (hwcap & COMPAT_HWCAP_ISA_I) {
+		isa->i = true;
+	}
+	if (hwcap & COMPAT_HWCAP_ISA_M) {
+		isa->m = true;
+	}
+	if (hwcap & COMPAT_HWCAP_ISA_A) {
+		isa->a = true;
+	}
+	if (hwcap & COMPAT_HWCAP_ISA_F) {
+		isa->f = true;
+	}
+	if (hwcap & COMPAT_HWCAP_ISA_D) {
+		isa->d = true;
+	}
+	if (hwcap & COMPAT_HWCAP_ISA_C) {
+		isa->c = true;
+	}
+	if (hwcap & COMPAT_HWCAP_ISA_V) {
+		isa->v = true;
+	}
+}

--- a/src/riscv/uarch.c
+++ b/src/riscv/uarch.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+#include <cpuinfo/log.h>
+#include <riscv/api.h>
+
+void cpuinfo_riscv_decode_vendor_uarch(
+	uint32_t vendor_id,
+	uint32_t arch_id,
+	uint32_t imp_id,
+	enum cpuinfo_vendor vendor[restrict static 1],
+	enum cpuinfo_uarch uarch[restrict static 1]) {
+	/* The vendor ID is sufficient to determine the cpuinfo_vendor. */
+	switch(vendor_id) {
+		case cpuinfo_riscv_chipset_sifive:
+			*vendor = cpuinfo_vendor_sifive;
+			break;
+		default:
+			*vendor = cpuinfo_vendor_unknown;
+			cpuinfo_log_warning("unknown vendor ID: %"PRIu32, vendor_id);
+			break;
+	}
+	/**
+	 * TODO: Add support for parsing chipset architecture and implementation
+	 * IDs here, when a chipset of interest comes along.
+	 */
+	*uarch = cpuinfo_uarch_unknown;
+}

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -177,5 +177,15 @@ int main(int argc, char** argv) {
 		printf("\tPMULL: %s\n", cpuinfo_has_arm_pmull() ? "yes" : "no");
 		printf("\tCRC32: %s\n", cpuinfo_has_arm_crc32() ? "yes" : "no");
 #endif
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	printf("Instruction sets:\n");
+		printf("\tBase Integer: %s\n", cpuinfo_has_riscv_i() ? "yes" : "no");
+		printf("\tInteger Multiply/Divide: %s\n", cpuinfo_has_riscv_m() ? "yes" : "no");
+		printf("\tAtomics: %s\n", cpuinfo_has_riscv_a() ? "yes" : "no");
+		printf("\tSingle-Precision Floating-Point: %s\n", cpuinfo_has_riscv_f() ? "yes" : "no");
+		printf("\tDouble-Precision Floating-Point: %s\n", cpuinfo_has_riscv_d() ? "yes" : "no");
+		printf("\tCompressed: %s\n", cpuinfo_has_riscv_c() ? "yes" : "no");
+		printf("\tVector: %s\n", cpuinfo_has_riscv_v() ? "yes" : "no");
+#endif
 
 }


### PR DESCRIPTION
Adds the cpuinfo.h definitions for RISCV32 and RISCV64 and declares the structure for RISCV ISA. Implements the initialization logic for Linux-based RISCV devices but only populates the ISA structure. The initialization is intentionally set to always fail, as this initial commit does not populate all other relevant cpu information, like processor data.

Test: Built and ran isa_info on a RISC-V QEMU instance, confirmed that it properly reports ISA information.