### PR TITLE
Add detection of Intel x86 AVX-VNNI instructions.

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -729,6 +729,7 @@ void CPUINFO_ABI cpuinfo_deinitialize(void);
 		bool sse4a;
 		bool misaligned_sse;
 		bool avx;
+		bool avxvnni;
 		bool fma3;
 		bool fma4;
 		bool xop;
@@ -1071,6 +1072,14 @@ static inline bool cpuinfo_has_x86_misaligned_sse(void) {
 static inline bool cpuinfo_has_x86_avx(void) {
 	#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 		return cpuinfo_isa.avx;
+	#else
+		return false;
+	#endif
+}
+
+static inline bool cpuinfo_has_x86_avxvnni(void) {
+	#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+		return cpuinfo_isa.avxvnni;
 	#else
 		return false;
 	#endif

--- a/src/x86/isa.c
+++ b/src/x86/isa.c
@@ -497,6 +497,12 @@ struct cpuinfo_x86_isa cpuinfo_x86_detect_isa(
 	isa.avx512fp16 = avx512_regs && !!(structured_feature_info0.edx & UINT32_C(0x00800000));
 
 	/*
+	 * AVX_VNNI instructions:
+	 * - Intel: eax[bit 4] in structured feature info (ecx = 1).
+	 */
+	isa.avxvnni = avx_regs && !!(structured_feature_info1.eax & UINT32_C(0x00000010));
+
+	/*
 	 * AVX512_BF16 instructions:
 	 * - Intel: eax[bit 5] in structured feature info (ecx = 1).
 	 */

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
 		printf("\tAVX512VP2INTERSECT: %s\n", cpuinfo_has_x86_avx512vp2intersect() ? "yes" : "no");
 		printf("\tAVX512_4VNNIW: %s\n", cpuinfo_has_x86_avx512_4vnniw() ? "yes" : "no");
 		printf("\tAVX512_4FMAPS: %s\n", cpuinfo_has_x86_avx512_4fmaps() ? "yes" : "no");
+                printf("\tAVXVNNI: %s\n", cpuinfo_has_x86_avxvnni() ? "yes" : "no");
 
 
 	printf("Multi-threading extensions:\n");


### PR DESCRIPTION
Tested using Intel SDE:

```
bash scripts/local-build.sh

OPTIONS=()
PLATFORMS=()

OPTIONS+=(-quark); PLATFORMS+=("Quark")
OPTIONS+=(-p4); PLATFORMS+=("Pentium4")
OPTIONS+=(-p4p); PLATFORMS+=("Pentium4 Prescott")
OPTIONS+=(-mrm); PLATFORMS+=("Merom")
OPTIONS+=(-pnr); PLATFORMS+=("Penryn")
OPTIONS+=(-nhm); PLATFORMS+=("Nehalem")
OPTIONS+=(-wsm); PLATFORMS+=("Westmere")
OPTIONS+=(-snb); PLATFORMS+=("Sandy Bridge")
OPTIONS+=(-ivb); PLATFORMS+=("Ivy Bridge")
OPTIONS+=(-hsw); PLATFORMS+=("Haswell")
OPTIONS+=(-bdw); PLATFORMS+=("Broadwell")
OPTIONS+=(-slt); PLATFORMS+=("Saltwell")
OPTIONS+=(-slm); PLATFORMS+=("Silvermont")
OPTIONS+=(-glm); PLATFORMS+=("Goldmont")
OPTIONS+=(-glp); PLATFORMS+=("Goldmont Plus")
OPTIONS+=(-tnt); PLATFORMS+=("Tremont")
OPTIONS+=(-snr); PLATFORMS+=("Snow Ridge")
OPTIONS+=(-skl); PLATFORMS+=("Skylake")
OPTIONS+=(-cnl); PLATFORMS+=("Cannon Lake")
OPTIONS+=(-icl); PLATFORMS+=("Ice Lake")
OPTIONS+=(-skx); PLATFORMS+=("Skylake server")
OPTIONS+=(-clx); PLATFORMS+=("Cascade Lake")
OPTIONS+=(-cpx); PLATFORMS+=("Cooper Lake")
OPTIONS+=(-icx); PLATFORMS+=("Ice Lake server")
OPTIONS+=(-knl); PLATFORMS+=("Knights landing")
OPTIONS+=(-knm); PLATFORMS+=("Knights mill")
OPTIONS+=(-tgl); PLATFORMS+=("Tiger Lake")
OPTIONS+=(-adl); PLATFORMS+=("Alder Lake")
OPTIONS+=(-mtl); PLATFORMS+=("Meteor Lake")
OPTIONS+=(-rpl); PLATFORMS+=("Raptor Lake")
OPTIONS+=(-spr); PLATFORMS+=("Sapphire Rapids")
OPTIONS+=(-gnr); PLATFORMS+=("Granite Rapids")
OPTIONS+=(-srf); PLATFORMS+=("Sierra Forest")
OPTIONS+=(-grr); PLATFORMS+=("Grand Ridge")
OPTIONS+=(-future); PLATFORMS+=("Future chip")

SDE_BIN="path/to/sde"

for I in "${!PLATFORMS[@]}"; do
  echo "${PLATFORMS["${I}"]}"
  "${SDE_BIN}" "${OPTIONS[$I]}" -- ./build/local/isa-info | grep "AVXVNNI"
done
```

Result:

```
[...}
Silvermont
        AVXVNNI: no
Goldmont
        AVXVNNI: no
Goldmont Plus
        AVXVNNI: no
Tremont
        AVXVNNI: no
Snow Ridge
        AVXVNNI: no
Skylake
        AVXVNNI: no
Cannon Lake
        AVXVNNI: no
Ice Lake
        AVXVNNI: no
Skylake server
        AVXVNNI: no
Cascade Lake
        AVXVNNI: no
Cooper Lake
        AVXVNNI: no
Ice Lake server
        AVXVNNI: no
Knights landing
        AVXVNNI: no
Knights mill
        AVXVNNI: no
Tiger Lake
        AVXVNNI: no
Alder Lake
        AVXVNNI: yes
Meteor Lake
        AVXVNNI: yes
Raptor Lake
        AVXVNNI: yes
Sapphire Rapids
        AVXVNNI: yes
Granite Rapids
        AVXVNNI: yes
Sierra Forest
        AVXVNNI: yes
Grand Ridge
        AVXVNNI: yes
Future chip
        AVXVNNI: yes
```