### PR TITLE
Add android_riscv64 to BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -300,6 +300,15 @@ config_setting(
 )
 
 config_setting(
+    name = "android_riscv64",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+        "cpu": "riscv64",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "android_x86",
     values = {
         "crosstool_top": "//external:android/crosstool",


### PR DESCRIPTION
Downstream projects that process the Bazel file were failing as the recent introduction of the 'android_riscv64' target did not have a corresponding config_setting.