### PR TITLE
Free resources in cpuinfo_deinitialize

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -4,6 +4,9 @@
 	#include <pthread.h>
 #endif
 
+#include <inttypes.h>
+#include <string.h>
+
 #include <cpuinfo.h>
 #include <cpuinfo/internal-api.h>
 #include <cpuinfo/log.h>
@@ -64,4 +67,34 @@ bool CPUINFO_ABI cpuinfo_initialize(void) {
 }
 
 void CPUINFO_ABI cpuinfo_deinitialize(void) {
+	cpuinfo_is_initialized = false;
+
+	free(cpuinfo_processors);
+	free(cpuinfo_cores);
+	free(cpuinfo_clusters);
+	free(cpuinfo_packages);
+	for (size_t cache_level = 0; cache_level < cpuinfo_cache_level_max; cache_level++) {
+		free(cpuinfo_cache[cache_level]);
+	}
+	memset(cpuinfo_cache, 0, cpuinfo_cache_level_max * sizeof(struct cpuinfo_cache*));
+
+	cpuinfo_processors_count = 0;
+	cpuinfo_cores_count = 0;
+	cpuinfo_clusters_count = 0;
+	cpuinfo_packages_count = 0;
+	memset(cpuinfo_cache_count, 0, cpuinfo_cache_level_max * sizeof(uint32_t));
+	cpuinfo_max_cache_size = 0;
+
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 || CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	free(cpuinfo_uarchs);
+	cpuinfo_uarchs_count = 0;
+#else
+	memset(&cpuinfo_global_uarch, 0, sizeof(struct cpuinfo_uarch_info));
+#endif // CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64 || CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+
+#ifdef __linux__
+	free(cpuinfo_linux_cpu_to_processor_map);
+	free(cpuinfo_linux_cpu_to_core_map);
+	cpuinfo_linux_cpu_max = 0;
+#endif // __linux__
 }


### PR DESCRIPTION
Users of the library can choose to release all resources the library may have allocated as part of a previous cpuinfo_initialize call. If no resources were previously allocated, this function does nothing.

Callers cannot re-initialize after the cpuinfo_deintialize call, as the library assumes initialization is a one-time operation per-process. Further, de-initializing can invalidate pointers previously acquired from cpuinfo (e.g. structures returned from cpuinfo_get_current_processor).

As such, callers should only call cpuinfo_deinitialize when:
1. There are no further uses of references returned from cpuinfo.
2. There are no further calls to cpuinfo_* functions.

Fixes #150 