### PR TITLE
Fix chipset enum name to include 'vendor_'

### DIFF
--- a/src/riscv/api.h
+++ b/src/riscv/api.h
@@ -8,7 +8,7 @@
 /* RISC-V Vendor IDs. */
 enum cpuinfo_riscv_chipset_vendor {
 	cpuinfo_riscv_chipset_vendor_unknown = 0,
-	cpuinfo_riscv_chipset_sifive = 0x489,
+	cpuinfo_riscv_chipset_vendor_sifive = 0x489,
 	cpuinfo_riscv_chipset_vendor_max,
 };
 

--- a/src/riscv/uarch.c
+++ b/src/riscv/uarch.c
@@ -11,7 +11,7 @@ void cpuinfo_riscv_decode_vendor_uarch(
 	enum cpuinfo_uarch uarch[restrict static 1]) {
 	/* The vendor ID is sufficient to determine the cpuinfo_vendor. */
 	switch(vendor_id) {
-		case cpuinfo_riscv_chipset_sifive:
+		case cpuinfo_riscv_chipset_vendor_sifive:
 			*vendor = cpuinfo_vendor_sifive;
 			break;
 		default:


### PR DESCRIPTION
The original change that introduced this should have used a consistent prefix for all enum types, for consistency sake.