### PR TITLE
Improve smallfile callback

### DIFF
--- a/src/linux/api.h
+++ b/src/linux/api.h
@@ -26,7 +26,7 @@
 
 typedef bool (*cpuinfo_cpulist_callback)(uint32_t, uint32_t, void*);
 CPUINFO_INTERNAL bool cpuinfo_linux_parse_cpulist(const char* filename, cpuinfo_cpulist_callback callback, void* context);
-typedef bool (*cpuinfo_smallfile_callback)(const char*, const char*, void*);
+typedef bool (*cpuinfo_smallfile_callback)(const char*, const char*, const char*, void*);
 CPUINFO_INTERNAL bool cpuinfo_linux_parse_small_file(const char* filename, size_t buffer_size, cpuinfo_smallfile_callback, void* context);
 typedef bool (*cpuinfo_line_callback)(const char*, const char*, void*, uint64_t);
 CPUINFO_INTERNAL bool cpuinfo_linux_parse_multiline_file(const char* filename, size_t buffer_size, cpuinfo_line_callback, void* context);

--- a/src/linux/processors.c
+++ b/src/linux/processors.c
@@ -88,7 +88,7 @@ inline static bool is_whitespace(char c) {
 	static const uint32_t default_max_processors_count = CPU_SETSIZE;
 #endif
 
-static bool uint32_parser(const char* text_start, const char* text_end, void* context) {
+static bool uint32_parser(const char* filename, const char* text_start, const char* text_end, void* context) {
 	if (text_start == text_end) {
 		cpuinfo_log_error("failed to parse file %s: file is empty", KERNEL_MAX_FILENAME);
 		return false;
@@ -98,13 +98,13 @@ static bool uint32_parser(const char* text_start, const char* text_end, void* co
 	const char* parsed_end = parse_number(text_start, text_end, &kernel_max);
 	if (parsed_end == text_start) {
 		cpuinfo_log_error("failed to parse file %s: \"%.*s\" is not an unsigned number",
-			KERNEL_MAX_FILENAME, (int) (text_end - text_start), text_start);
+			filename, (int) (text_end - text_start), text_start);
 		return false;
 	} else {
 		for (const char* char_ptr = parsed_end; char_ptr != text_end; char_ptr++) {
 			if (!is_whitespace(*char_ptr)) {
 				cpuinfo_log_warning("non-whitespace characters \"%.*s\" following number in file %s are ignored",
-					(int) (text_end - char_ptr), char_ptr, KERNEL_MAX_FILENAME);
+					(int) (text_end - char_ptr), char_ptr, filename);
 				break;
 			}
 		}

--- a/src/linux/smallfile.c
+++ b/src/linux/smallfile.c
@@ -55,7 +55,7 @@ bool cpuinfo_linux_parse_small_file(const char* filename, size_t buffer_size, cp
 		}
 	} while (bytes_read != 0);
 
-	status = callback(buffer, &buffer[buffer_position], context);
+	status = callback(filename, buffer, &buffer[buffer_position], context);
 
 cleanup:
 	if (file != -1) {


### PR DESCRIPTION
This PR improves the smallfile callback error reporting, passing the name of the inspected file in the `filename` argument instead of forcing it to be `KERNEL_MAX_FILENAME` as before.