### PR TITLE
Fix RISC-V Linux build again

### DIFF
--- a/src/riscv/linux/riscv-hw.c
+++ b/src/riscv/linux/riscv-hw.c
@@ -14,7 +14,6 @@
 #endif
 
 #include <sched.h>
-#include <sys/hwprobe.h>
 
 #include <cpuinfo/log.h>
 #include <riscv/api.h>


### PR DESCRIPTION
PR https://github.com/pytorch/cpuinfo/pull/204 broke the RISC-V build by including for a second time a header file that currently only exists in the RISC-V Android NDK.  The header is not yet available in mainstream Linux distributions.  The header in question, <sys/hwprobe.h>, is already included when building for Android at the top of riscv-hw.c so the second include is unnecessary and can be safely removed.