### PR TITLE
ci: Add an Ubuntu:22.04 builder for RISC-V

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,3 +93,27 @@ jobs:
         working-directory: ${{ github.workspace }}
         env:
           ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
+  cmake-linux-qemu:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        build_props:
+          - [
+              "riscv64",
+              "riscv64/ubuntu:22.04"
+          ]
+    env:
+      ARCH_NAME: ${{ matrix.build_props[0] }}
+      DOCKER_IMAGE: ${{ matrix.build_props[1] }}
+
+    name: ${ARCH_NAME}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install qemu and setup binfmt_misc
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Build cpuinfo in ${DOCKER_IMAGE}
+          docker run -i -v $(pwd):/cpuinfo ${DOCKER_IMAGE} /bin/bash -c "
+          apt update &&
+          apt install -y cmake git gcc g++ &&
+          scripts/local-build.sh"


### PR DESCRIPTION
cpuinfo is built for riscv64 using a riscv64 container.  binfmt_misc allows the riscv64 binaries in the container to be executed with QEMU. This is slower than cross compiling but as there's not that much code the build times are acceptable.  It should be easy to expand the matrix to add CI for other architectures not natively supported by github actions.