### PR TITLE
Update cpuinfo.h: add support for ARM64EC

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -18,7 +18,7 @@
 #define CPUINFO_ARCH_X86 1
 #endif
 
-#if defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+#if defined(__x86_64__) || defined(__x86_64) || (defined(_M_X64) && !defined(_M_ARM64EC)) || (defined(_M_AMD64) && !defined(_M_ARM64EC))
 #define CPUINFO_ARCH_X86_64 1
 #endif
 
@@ -26,7 +26,7 @@
 #define CPUINFO_ARCH_ARM 1
 #endif
 
-#if defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #define CPUINFO_ARCH_ARM64 1
 #endif
 


### PR DESCRIPTION
To fix a build error:
```
src\arm\windows\init-by-logical-sys-info.c(309,17): Error C2065: 'cpuinfo_uarchs': undeclared identifier
```
In short, Arm64EC is a new application binary interface (ABI) for apps running on Arm devices with an x64 like ABI.

Reference: 
1. [VC++ predefined-macros](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170)
2. [ARM64EC overview](https://learn.microsoft.com/en-us/windows/arm/arm64ec)
