### PR TITLE
add detection for intel new isa: avx_ne_convert, avx_vnni_int8, avx_vnni_int16

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -816,6 +816,9 @@ struct cpuinfo_x86_isa {
 	bool amx_tile;
 	bool amx_int8;
 	bool amx_fp16;
+	bool avx_vnni_int8;
+	bool avx_vnni_int16;
+	bool avx_ne_convert;
 	bool hle;
 	bool rtm;
 	bool xtest;
@@ -1379,6 +1382,46 @@ static inline bool cpuinfo_has_x86_amx_int8(void) {
 static inline bool cpuinfo_has_x86_amx_fp16(void) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 	return cpuinfo_isa.amx_fp16;
+#else
+	return false;
+#endif
+}
+
+/*
+ * Intel AVX Vector Neural Network Instructions (VNNI) INT8
+ * Supported Platfroms: Sierra Forest, Arrow Lake, Lunar Lake
+ */
+static inline bool cpuinfo_has_x86_avx_vnni_int8(void) {
+#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+	return cpuinfo_isa.avx_vnni_int8;
+#else
+	return false;
+#endif
+}
+
+/*
+ * Intel AVX Vector Neural Network Instructions (VNNI) INT16
+ * Supported Platfroms: Arrow Lake, Lunar Lake
+ */
+static inline bool cpuinfo_has_x86_avx_vnni_int16(void) {
+#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+	return cpuinfo_isa.avx_vnni_int16;
+#else
+	return false;
+#endif
+}
+
+/*
+ * A new set of instructions, which can convert low precision floating point
+ * like BF16/FP16 to high precision floating point FP32, as well as convert FP32
+ * elements to BF16. This instruction allows the platform to have improved AI
+ * capabilities and better compatibility.
+ *
+ * Supported Platforms: Sierra Forest, Arrow Lake, Lunar Lake
+ */
+static inline bool cpuinfo_has_x86_avx_ne_convert(void) {
+#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+	return cpuinfo_isa.avx_ne_convert;
 #else
 	return false;
 #endif

--- a/src/x86/isa.c
+++ b/src/x86/isa.c
@@ -562,6 +562,24 @@ struct cpuinfo_x86_isa cpuinfo_x86_detect_isa(
 	isa.amx_fp16 = avx512_regs && !!(structured_feature_info1.eax & UINT32_C(0x00200000));
 
 	/*
+	 * AVX_VNNI_INT8 instructions:
+	 * - Intel: edx[bit 4] in structured feature info (ecx = 1).
+	 */
+	isa.avx_vnni_int8 = avx_regs && !!(structured_feature_info1.edx & UINT32_C(0x00000010));
+
+	/*
+	 * AVX_VNNI_INT16 instructions:
+	 * - Intel: edx[bit 10] in structured feature info (ecx = 1).
+	 */
+	isa.avx_vnni_int16 = avx_regs && !!(structured_feature_info1.edx & UINT32_C(0x00000400));
+
+	/*
+	 * AVX_NE_CONVERT instructions:
+	 * - Intel: edx[bit 5] in structured feature info (ecx = 1).
+	 */
+	isa.avx_ne_convert = avx_regs && !!(structured_feature_info1.edx & UINT32_C(0x00000020));
+
+	/*
 	 * HLE instructions:
 	 * - Intel: ebx[bit 4] in structured feature info (ecx = 0).
 	 */

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -75,6 +75,9 @@ int main(int argc, char** argv) {
 	printf("\tAMX_INT8: %s\n", cpuinfo_has_x86_amx_int8() ? "yes" : "no");
 	printf("\tAMX_FP16: %s\n", cpuinfo_has_x86_amx_fp16() ? "yes" : "no");
 	printf("\tAVXVNNI: %s\n", cpuinfo_has_x86_avxvnni() ? "yes" : "no");
+	printf("\tAVX_VNNI_INT8: %s\n", cpuinfo_has_x86_avx_vnni_int8() ? "yes" : "no");
+	printf("\tAVX_VNNI_INT16: %s\n", cpuinfo_has_x86_avx_vnni_int16() ? "yes" : "no");
+	printf("\tAVX_NE_CONVERT: %s\n", cpuinfo_has_x86_avx_ne_convert() ? "yes" : "no");
 
 	printf("Multi-threading extensions:\n");
 	printf("\tMONITOR/MWAIT: %s\n", cpuinfo_has_x86_mwait() ? "yes" : "no");


### PR DESCRIPTION
Test Plan:
```
bash scripts/local-build.sh

ISAS=()
OPTIONS=()
PLATFORMS=()

OPTIONS+=(-quark); PLATFORMS+=("Quark")
OPTIONS+=(-p4); PLATFORMS+=("Pentium4")
OPTIONS+=(-p4p); PLATFORMS+=("Pentium4 Prescott")
OPTIONS+=(-mrm); PLATFORMS+=("Merom")
OPTIONS+=(-pnr); PLATFORMS+=("Penryn")
OPTIONS+=(-nhm); PLATFORMS+=("Nehalem")
OPTIONS+=(-wsm); PLATFORMS+=("Westmere")
OPTIONS+=(-snb); PLATFORMS+=("Sandy Bridge")
OPTIONS+=(-ivb); PLATFORMS+=("Ivy Bridge")
OPTIONS+=(-hsw); PLATFORMS+=("Haswell")
OPTIONS+=(-bdw); PLATFORMS+=("Broadwell")
OPTIONS+=(-slt); PLATFORMS+=("Saltwell")
OPTIONS+=(-slm); PLATFORMS+=("Silvermont")
OPTIONS+=(-glm); PLATFORMS+=("Goldmont")
OPTIONS+=(-glp); PLATFORMS+=("Goldmont Plus")
OPTIONS+=(-tnt); PLATFORMS+=("Tremont")
OPTIONS+=(-snr); PLATFORMS+=("Snow Ridge")
OPTIONS+=(-skl); PLATFORMS+=("Skylake")
OPTIONS+=(-cnl); PLATFORMS+=("Cannon Lake")
OPTIONS+=(-icl); PLATFORMS+=("Ice Lake")
OPTIONS+=(-skx); PLATFORMS+=("Skylake server")
OPTIONS+=(-clx); PLATFORMS+=("Cascade Lake")
OPTIONS+=(-cpx); PLATFORMS+=("Cooper Lake")
OPTIONS+=(-icx); PLATFORMS+=("Ice Lake server")
OPTIONS+=(-knl); PLATFORMS+=("Knights landing")
OPTIONS+=(-knm); PLATFORMS+=("Knights mill")
OPTIONS+=(-tgl); PLATFORMS+=("Tiger Lake")
OPTIONS+=(-adl); PLATFORMS+=("Alder Lake")
OPTIONS+=(-mtl); PLATFORMS+=("Meteor Lake")
OPTIONS+=(-rpl); PLATFORMS+=("Raptor Lake")
OPTIONS+=(-spr); PLATFORMS+=("Sapphire Rapids")
OPTIONS+=(-gnr); PLATFORMS+=("Granite Rapids")
OPTIONS+=(-gnr256); PLATFORMS+=("Granite Rapids (AVX10.1 / 256VL)")
OPTIONS+=(-srf); PLATFORMS+=("Sierra Forest")
OPTIONS+=(-arl); PLATFORMS+=("Arrow Lake")
OPTIONS+=(-lnl); PLATFORMS+=("Lunar Lake")
OPTIONS+=(-future); PLATFORMS+=("Future chip")

ISAS+=("AVX_VNNI_INT8")
ISAS+=("AVX_VNNI_INT16")
ISAS+=("AVX_NE_CONVERT")

SDE_BIN="/home/mingfeim/packages/sde-external-9.33.0-2024-01-07-lin/sde"

for I in "${!PLATFORMS[@]}"; do
  echo "${PLATFORMS["${I}"]}"
    for J in "${!ISAS[@]}"; do
      "${SDE_BIN}" "${OPTIONS[$I]}" -- ./build/local/isa-info | grep ${ISAS[$J]}
    done
done
```

Results:
```
Quark
SDE-ERROR: 64 bits applications are not supported by input chip: PENTIUM or by the input cpuid definition file
SDE-ERROR: 64 bits applications are not supported by input chip: PENTIUM or by the input cpuid definition file
SDE-ERROR: 64 bits applications are not supported by input chip: PENTIUM or by the input cpuid definition file
Pentium4
SDE-ERROR: 64 bits applications are not supported by input chip: PENTIUM4 or by the input cpuid definition file
SDE-ERROR: 64 bits applications are not supported by input chip: PENTIUM4 or by the input cpuid definition file
SDE-ERROR: 64 bits applications are not supported by input chip: PENTIUM4 or by the input cpuid definition file
Pentium4 Prescott
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Merom
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Penryn
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Nehalem
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Westmere
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Sandy Bridge
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Ivy Bridge
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Haswell
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Broadwell
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Saltwell
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Silvermont
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Goldmont
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Goldmont Plus
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Tremont
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Snow Ridge
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Skylake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Cannon Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Ice Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Skylake server
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Cascade Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Cooper Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Ice Lake server
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Knights landing
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Knights mill
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Tiger Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Alder Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Meteor Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Raptor Lake
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Sapphire Rapids
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Granite Rapids
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Granite Rapids (AVX10.1 / 256VL)
        AVX_VNNI_INT8: no
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: no
Sierra Forest
        AVX_VNNI_INT8: yes
        AVX_VNNI_INT16: no
        AVX_NE_CONVERT: yes
Arrow Lake
        AVX_VNNI_INT8: yes
        AVX_VNNI_INT16: yes
        AVX_NE_CONVERT: yes
Lunar Lake
        AVX_VNNI_INT8: yes
        AVX_VNNI_INT16: yes
        AVX_NE_CONVERT: yes
Future chip
        AVX_VNNI_INT8: yes
        AVX_VNNI_INT16: yes
        AVX_NE_CONVERT: yes
```