### PR TITLE
Implementing Cpuinfo for Power architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ IF(NOT CMAKE_SYSTEM_PROCESSOR)
       "cpuinfo will compile, but cpuinfo_initialize() will always fail.")
     SET(CPUINFO_SUPPORTED_PLATFORM FALSE)
   ENDIF()
-ELSEIF(NOT CPUINFO_TARGET_PROCESSOR MATCHES "^(i[3-6]86|AMD64|x86(_64)?|armv[5-8].*|aarch64|arm64.*|ARM64.*|riscv(32|64))$")
+ELSEIF(NOT CPUINFO_TARGET_PROCESSOR MATCHES "^(i[3-6]86|AMD64|x86(_64)?|armv[5-8].*|aarch64|arm64.*|ARM64.*|riscv(32|64)|ppc64le)$")
   MESSAGE(WARNING
     "Target processor architecture \"${CPUINFO_TARGET_PROCESSOR}\" is not supported in cpuinfo. "
     "cpuinfo will compile, but cpuinfo_initialize() will always fail.")
@@ -179,8 +179,18 @@ IF(CPUINFO_SUPPORTED_PLATFORM)
     ELSEIF(CMAKE_SYSTEM_NAME MATCHES "^(Windows|WindowsStore|CYGWIN|MSYS)$")
       LIST(APPEND CPUINFO_SRCS src/x86/windows/init.c)
     ENDIF()
+  ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64le)$" )
+	  LIST(APPEND CPUINFO_SRCS
+		  src/powerpc/cache.c
+		  src/powerpc/uarch.c
+		  src/powerpc/linux/chipset.c
+		  src/powerpc/linux/clusters.c
+		  src/powerpc/linux/cpuinfo.c
+		  src/powerpc/linux/hwcap.c
+		  src/powerpc/linux/init.c
+		  src/powerpc/linux/ppc64-isa.c)
   ELSEIF(CMAKE_SYSTEM_NAME MATCHES "^Windows" AND CPUINFO_TARGET_PROCESSOR MATCHES "^(ARM64|arm64)$")
-    LIST(APPEND CPUINFO_SRCS
+	  LIST(APPEND CPUINFO_SRCS
       src/arm/windows/init-by-logical-sys-info.c
       src/arm/windows/init.c)
   ELSEIF(CPUINFO_TARGET_PROCESSOR MATCHES "^(armv[5-8].*|aarch64|arm64.*)$" OR IOS_ARCH MATCHES "^(armv7.*|arm64.*)$")
@@ -913,3 +923,5 @@ IF(CPUINFO_BUILD_PKG_CONFIG)
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 ENDIF()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -ggdb")

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -11,6 +11,7 @@
 #endif
 
 #include <stdint.h>
+#include <sys/auxv.h>
 
 /* Identify architecture and define corresponding macro */
 
@@ -593,6 +594,21 @@ enum cpuinfo_uarch {
 
 	/** HiSilicon TaiShan v110 (Huawei Kunpeng 920 series processors). */
 	cpuinfo_uarch_taishan_v110 = 0x00C00100,
+
+	/** POWER 7. */
+	cpuinfo_uarch_power7    = 0x00D00100,
+	/** POWER 7p. */
+	cpuinfo_uarch_power7p   = 0x00D00101,
+	/** POWER 8. */
+	cpuinfo_uarch_power8    = 0x00D00200,
+	/** POWER8E. */
+	cpuinfo_uarch_power8e   = 0x00D00201,
+	/** POWER8NVL */
+	cpuinfo_uarch_power8nvl = 0x00D00202,
+	/** POWER 9. */
+	cpuinfo_uarch_power9    = 0x00D00303,
+	/** POWER 10. */
+	cpuinfo_uarch_power10   = 0x00D00400,
 };
 
 struct cpuinfo_processor {
@@ -663,9 +679,14 @@ struct cpuinfo_core {
 #elif CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 	/** Value of Main ID Register (MIDR) for this core */
 	uint32_t midr;
+#elif CPUINFO_ARCH_PPC64
+	/** Value of Processor Version Register for this core */
+	uint32_t pvr;
 #endif
 	/** Clock rate (non-Turbo) of the core, in Hz */
 	uint64_t frequency;
+
+	bool disabled;
 };
 
 struct cpuinfo_cluster {
@@ -691,6 +712,9 @@ struct cpuinfo_cluster {
 #elif CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 	/** Value of Main ID Register (MIDR) of the cores in the cluster */
 	uint32_t midr;
+#elif CPUINFO_ARCH_PPC64
+	/** Value of Processor Version Register in this cluster */
+	uint32_t pvr;
 #endif
 	/** Clock rate (non-Turbo) of the cores in the cluster, in Hz */
 	uint64_t frequency;
@@ -724,6 +748,9 @@ struct cpuinfo_uarch_info {
 #elif CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 	/** Value of Main ID Register (MIDR) for the microarchitecture */
 	uint32_t midr;
+#elif CPUINFO_ARCH_PPC64
+	/** Value of Processor Version Register for this core */
+	uint32_t pvr;
 #endif
 	/** Number of logical processors with the microarchitecture */
 	uint32_t processor_count;
@@ -2091,6 +2118,40 @@ static inline bool cpuinfo_has_riscv_v(void) {
 	return cpuinfo_isa.v;
 #else
 	return false;
+#endif
+}
+
+#if CPUINFO_ARCH_PPC64
+	struct cpuinfo_powerpc_isa {
+		bool vsx;
+		bool htm;
+		bool mma;
+	};
+
+	extern struct cpuinfo_powerpc_isa cpuinfo_isa;
+#endif
+
+static inline bool cpuinfo_has_powerpc_vsx(void) {
+#if CPUINFO_ARCH_PPC64
+	return cpuinfo_isa.vsx;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_powerpc_htm(void) {
+#if CPUINFO_ARCH_PPC64
+	return cpuinfo_isa.htm;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_powerpc_mma(void) {
+#if CPUINFO_ARCH_PPC64
+	return cpuinfo_isa.mma;
+#else
+		return false;
 #endif
 }
 

--- a/src/cpuinfo/internal-api.h
+++ b/src/cpuinfo/internal-api.h
@@ -60,6 +60,7 @@ CPUINFO_PRIVATE void cpuinfo_arm_mach_init(void);
 CPUINFO_PRIVATE void cpuinfo_arm_linux_init(void);
 CPUINFO_PRIVATE void cpuinfo_riscv_linux_init(void);
 CPUINFO_PRIVATE void cpuinfo_emscripten_init(void);
+CPUINFO_PRIVATE void cpuinfo_powerpc_linux_init(void);
 
 CPUINFO_PRIVATE uint32_t cpuinfo_compute_max_cache_size(const struct cpuinfo_processor* processor);
 

--- a/src/init.c
+++ b/src/init.c
@@ -31,6 +31,12 @@ bool CPUINFO_ABI cpuinfo_initialize(void) {
 #else
 	cpuinfo_log_error("operating system is not supported in cpuinfo");
 #endif
+#elif CPUINFO_ARCH_PPC64
+	#if defined(__linux__)
+		pthread_once(&init_guard, &cpuinfo_powerpc_linux_init);
+	#else
+		cpuinfo_log_error("operating system is not supported in cpuinfo");
+#endif
 #elif CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
 #if defined(__linux__)
 	pthread_once(&init_guard, &cpuinfo_arm_linux_init);

--- a/src/linux/api.h
+++ b/src/linux/api.h
@@ -22,6 +22,7 @@
 #define CPUINFO_LINUX_FLAG_VALID UINT32_C(0x00001000)
 #define CPUINFO_LINUX_FLAG_CUR_FREQUENCY UINT32_C(0x00002000)
 #define CPUINFO_LINUX_FLAG_CLUSTER_CLUSTER UINT32_C(0x00004000)
+#define CPUINFO_LINUX_MASK_USABLE UINT32_C(0x00000003)
 
 typedef bool (*cpuinfo_cpulist_callback)(uint32_t, uint32_t, void*);
 CPUINFO_INTERNAL bool cpuinfo_linux_parse_cpulist(

--- a/src/linux/processors.c
+++ b/src/linux/processors.c
@@ -54,6 +54,12 @@
 inline static const char* parse_number(const char* start, const char* end, uint32_t number_ptr[restrict static 1]) {
 	uint32_t number = 0;
 	const char* parsed = start;
+	if (*parsed == '-')
+	{
+		*number_ptr = 0;
+		static const char newline[] = "\n";
+	        return newline;
+	}
 	for (; parsed != end; parsed++) {
 		const uint32_t digit = (uint32_t)(uint8_t)(*parsed) - (uint32_t)'0';
 		if (digit >= 10) {
@@ -83,7 +89,9 @@ inline static bool is_whitespace(char c) {
  * Android NDK headers before platform 21 do not define CPU_SETSIZE,
  * so we hard-code its value, as defined in platform 21 headers
  */
-#if defined(__LP64__)
+#if defined(__powerpc__)
+	static const uint32_t default_max_processors_count = 2048;
+#elif defined(__LP64__)
 static const uint32_t default_max_processors_count = 1024;
 #else
 static const uint32_t default_max_processors_count = 32;

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -272,6 +272,20 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "ThunderX2";
 		case cpuinfo_uarch_pj4:
 			return "PJ4";
+		case cpuinfo_uarch_power7:
+			return "POWER7";
+		case cpuinfo_uarch_power7p:
+			return "POWER7+";
+		case cpuinfo_uarch_power8:
+			return "POWER8";
+		case cpuinfo_uarch_power8e:
+			return "POWER8E";
+		case cpuinfo_uarch_power8nvl:
+			return "POWER8NVL";
+		case cpuinfo_uarch_power9:
+			return "POWER9";
+		case cpuinfo_uarch_power10:
+			return "POWER10";
 		case cpuinfo_uarch_brahma_b15:
 			return "Brahma B15";
 		case cpuinfo_uarch_brahma_b53:
@@ -315,6 +329,8 @@ int main(int argc, char** argv) {
 	printf("Cores:\n");
 	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
 		const struct cpuinfo_core* core = cpuinfo_get_core(i);
+		if (core->disabled)
+			continue;
 		if (core->processor_count == 1) {
 			printf("\t%" PRIu32 ": 1 processor (%" PRIu32 ")", i, core->processor_start);
 		} else {


### PR DESCRIPTION
This pull request implements support for the cpuinfo library on the Power architecture. The cpuinfo library provides CPU information and features detection, and this implementation extends its capabilities to work seamlessly on Power-based systems.
Changes Included:
Added support for detecting Power architecture in cpuinfo
Implemented Power-specific CPU feature detection

Testing:
I have tested this implementation on Power systems running it on Trout, Laurel (Power9 arch.) and Ltcden2-lp1 (Power10 arch.) to ensure compatibility and correctness. The tests cover feature detection and library functionality specific to Power architecture.

Purpose:
The purpose of this pull request is to enhance the cpuinfo library by adding support for Power architecture, enabling users of Power-based systems to utilize cpuinfo for CPU information retrieval and feature detection.
