### PR TITLE
Fixing Ampere Altra Processor detection

### DIFF
--- a/src/arm/windows/init.c
+++ b/src/arm/windows/init.c
@@ -22,49 +22,54 @@ static struct woa_chip_info woa_chip_unknown = {
 /* Please add new SoC/chip info here! */
 static struct woa_chip_info woa_chips[woa_chip_name_last] = {
 	/* Microsoft SQ1 Kryo 495 4 + 4 cores (3 GHz + 1.80 GHz) */
-	[woa_chip_name_microsoft_sq_1] = {L"Microsoft SQ1",
-	 woa_chip_name_microsoft_sq_1,
-	 {{
-		  cpuinfo_vendor_arm,
-		  cpuinfo_uarch_cortex_a55,
-		  1800000000,
-	  },
-	  {
-		  cpuinfo_vendor_arm,
-		  cpuinfo_uarch_cortex_a76,
-		  3000000000,
-	  }}},
+	[woa_chip_name_microsoft_sq_1] =
+		{L"Microsoft SQ1",
+		 woa_chip_name_microsoft_sq_1,
+		 {{
+			  cpuinfo_vendor_arm,
+			  cpuinfo_uarch_cortex_a55,
+			  1800000000,
+		  },
+		  {
+			  cpuinfo_vendor_arm,
+			  cpuinfo_uarch_cortex_a76,
+			  3000000000,
+		  }}},
 	/* Microsoft SQ2 Kryo 495 4 + 4 cores (3.15 GHz + 2.42 GHz) */
-	[woa_chip_name_microsoft_sq_2] = {L"Microsoft SQ2",
-	 woa_chip_name_microsoft_sq_2,
-	 {{
-		  cpuinfo_vendor_arm,
-		  cpuinfo_uarch_cortex_a55,
-		  2420000000,
-	  },
-	  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_a76, 3150000000}}},
+	[woa_chip_name_microsoft_sq_2] =
+		{L"Microsoft SQ2",
+		 woa_chip_name_microsoft_sq_2,
+		 {{
+			  cpuinfo_vendor_arm,
+			  cpuinfo_uarch_cortex_a55,
+			  2420000000,
+		  },
+		  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_a76, 3150000000}}},
 	/* Snapdragon (TM) 8cx Gen 3 @ 3.0 GHz */
-	[woa_chip_name_microsoft_sq_3] = {L"Snapdragon (TM) 8cx Gen 3",
-	 woa_chip_name_microsoft_sq_3,
-	 {{
-		  cpuinfo_vendor_arm,
-		  cpuinfo_uarch_cortex_a78,
-		  2420000000,
-	  },
-	  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_x1, 3000000000}}},
+	[woa_chip_name_microsoft_sq_3] =
+		{L"Snapdragon (TM) 8cx Gen 3",
+		 woa_chip_name_microsoft_sq_3,
+		 {{
+			  cpuinfo_vendor_arm,
+			  cpuinfo_uarch_cortex_a78,
+			  2420000000,
+		  },
+		  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_x1, 3000000000}}},
 	/* Microsoft Windows Dev Kit 2023 */
-	[woa_chip_name_microsoft_sq_3_devkit] = {L"Snapdragon Compute Platform",
-	 woa_chip_name_microsoft_sq_3_devkit,
-	 {{
-		  cpuinfo_vendor_arm,
-		  cpuinfo_uarch_cortex_a78,
-		  2420000000,
-	  },
-	  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_x1, 3000000000}}},
+	[woa_chip_name_microsoft_sq_3_devkit] =
+		{L"Snapdragon Compute Platform",
+		 woa_chip_name_microsoft_sq_3_devkit,
+		 {{
+			  cpuinfo_vendor_arm,
+			  cpuinfo_uarch_cortex_a78,
+			  2420000000,
+		  },
+		  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_x1, 3000000000}}},
 	/* Ampere Altra */
-	[woa_chip_name_ampere_altra] = {L"Ampere(R) Altra(R) Processor",
-	 woa_chip_name_ampere_altra,
-	 {{cpuinfo_vendor_arm, cpuinfo_uarch_neoverse_n1, 3000000000}}}};
+	[woa_chip_name_ampere_altra] = {
+		L"Ampere(R) Altra(R) Processor",
+		woa_chip_name_ampere_altra,
+		{{cpuinfo_vendor_arm, cpuinfo_uarch_neoverse_n1, 3000000000}}}};
 
 BOOL CALLBACK cpuinfo_arm_windows_init(PINIT_ONCE init_once, PVOID parameter, PVOID* context) {
 	struct woa_chip_info* chip_info = NULL;

--- a/src/arm/windows/init.c
+++ b/src/arm/windows/init.c
@@ -20,9 +20,9 @@ static struct woa_chip_info woa_chip_unknown = {
 	{{cpuinfo_vendor_unknown, cpuinfo_uarch_unknown, 0}}};
 
 /* Please add new SoC/chip info here! */
-static struct woa_chip_info woa_chips[] = {
+static struct woa_chip_info woa_chips[woa_chip_name_last] = {
 	/* Microsoft SQ1 Kryo 495 4 + 4 cores (3 GHz + 1.80 GHz) */
-	{L"Microsoft SQ1",
+	[woa_chip_name_microsoft_sq_1] = {L"Microsoft SQ1",
 	 woa_chip_name_microsoft_sq_1,
 	 {{
 		  cpuinfo_vendor_arm,
@@ -35,7 +35,7 @@ static struct woa_chip_info woa_chips[] = {
 		  3000000000,
 	  }}},
 	/* Microsoft SQ2 Kryo 495 4 + 4 cores (3.15 GHz + 2.42 GHz) */
-	{L"Microsoft SQ2",
+	[woa_chip_name_microsoft_sq_2] = {L"Microsoft SQ2",
 	 woa_chip_name_microsoft_sq_2,
 	 {{
 		  cpuinfo_vendor_arm,
@@ -44,7 +44,7 @@ static struct woa_chip_info woa_chips[] = {
 	  },
 	  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_a76, 3150000000}}},
 	/* Snapdragon (TM) 8cx Gen 3 @ 3.0 GHz */
-	{L"Snapdragon (TM) 8cx Gen 3",
+	[woa_chip_name_microsoft_sq_3] = {L"Snapdragon (TM) 8cx Gen 3",
 	 woa_chip_name_microsoft_sq_3,
 	 {{
 		  cpuinfo_vendor_arm,
@@ -53,8 +53,8 @@ static struct woa_chip_info woa_chips[] = {
 	  },
 	  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_x1, 3000000000}}},
 	/* Microsoft Windows Dev Kit 2023 */
-	{L"Snapdragon Compute Platform",
-	 woa_chip_name_microsoft_sq_3,
+	[woa_chip_name_microsoft_sq_3_devkit] = {L"Snapdragon Compute Platform",
+	 woa_chip_name_microsoft_sq_3_devkit,
 	 {{
 		  cpuinfo_vendor_arm,
 		  cpuinfo_uarch_cortex_a78,
@@ -62,7 +62,7 @@ static struct woa_chip_info woa_chips[] = {
 	  },
 	  {cpuinfo_vendor_arm, cpuinfo_uarch_cortex_x1, 3000000000}}},
 	/* Ampere Altra */
-	{L"Ampere(R) Altra(R) Processor",
+	[woa_chip_name_ampere_altra] = {L"Ampere(R) Altra(R) Processor",
 	 woa_chip_name_ampere_altra,
 	 {{cpuinfo_vendor_arm, cpuinfo_uarch_neoverse_n1, 3000000000}}}};
 

--- a/src/arm/windows/windows-arm-init.h
+++ b/src/arm/windows/windows-arm-init.h
@@ -8,8 +8,9 @@ enum woa_chip_name {
 	woa_chip_name_microsoft_sq_1 = 0,
 	woa_chip_name_microsoft_sq_2 = 1,
 	woa_chip_name_microsoft_sq_3 = 2,
-	woa_chip_name_ampere_altra = 3,
-	woa_chip_name_unknown = 4,
+	woa_chip_name_microsoft_sq_3_devkit = 3,
+	woa_chip_name_ampere_altra = 4,
+	woa_chip_name_unknown = 5,
 	woa_chip_name_last = woa_chip_name_unknown
 };
 


### PR DESCRIPTION
**Summary:**

Resolves #236

Also related to [PR 220](https://github.com/pytorch/cpuinfo/pull/220) change.

```
"Unknown chip model name 'Ampere(R) Altra(R) Processor'.
Please add new Windows on Arm SoC/chip support to arm/windows/init.c!"
```

---

**Previous error details:**

The error's reason was:

`woa_chip_name` (`windows-arm-init.h`)  enum had only 4 elements (stored in `woa_chip_name_last`)

```c
enum woa_chip_name {
	woa_chip_name_microsoft_sq_1 = 0,
	woa_chip_name_microsoft_sq_2 = 1,
	woa_chip_name_microsoft_sq_3 = 2,
	woa_chip_name_ampere_altra = 3,
	woa_chip_name_unknown = 4,
	woa_chip_name_last = woa_chip_name_unknown
};
```

However, `woa_chips[]`  (`init.c`) has a duplicated value for `woa_chip_name_microsoft_sq_3` due to different strings for same target after the [PR 220](https://github.com/pytorch/cpuinfo/pull/220)

> Strings are `Snapdragon (TM) 8cx Gen 3` and `Snapdragon Compute Platform`

And this was causing following `for loop` (`init.c`) is not checking for all elements in `woa_chips[]`.

```c
for (uint32_t i = 0; i < (uint32_t)woa_chip_name_last; i++) {
	size_t compare_length = wcsnlen(woa_chips[i].chip_name_string, CPUINFO_PACKAGE_NAME_MAX);
	int compare_result = wcsncmp(text_buffer, woa_chips[i].chip_name_string, compare_length);
	if (compare_result == 0) {
		chip_info = woa_chips + i;
		break;
	}
}
```

---

**Fix Details:**

We added `woa_chip_name_microsoft_sq_3_devkit` to maintain **one to one** relationship between `woa_chip_name` (`windows-arm-init.h`) and `woa_chips[]` (`init.c`).

Also, we especially specified indexes with `enums` to prevent future duplications and increase readability of the code and relationship.

