### PR TITLE
Use cluster_cpus_list to detect clusters for ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,11 @@ IF(CPUINFO_SUPPORTED_PLATFORM AND CPUINFO_BUILD_MOCK_TESTS)
     TARGET_LINK_LIBRARIES(pixel-2-xl-test PRIVATE cpuinfo_mock gtest)
     ADD_TEST(NAME pixel-2-xl-test COMMAND pixel-2-xl-test)
 
+    ADD_EXECUTABLE(pixel-8-test test/mock/pixel-8.cc)
+    TARGET_INCLUDE_DIRECTORIES(pixel-8-test BEFORE PRIVATE test/mock)
+    TARGET_LINK_LIBRARIES(pixel-8-test PRIVATE cpuinfo_mock gtest)
+    ADD_TEST(NAME pixel-8-test COMMAND pixel-8-test)
+
     ADD_EXECUTABLE(xiaomi-mi-5c-test test/mock/xiaomi-mi-5c.cc)
     TARGET_INCLUDE_DIRECTORIES(xiaomi-mi-5c-test BEFORE PRIVATE test/mock)
     TARGET_LINK_LIBRARIES(xiaomi-mi-5c-test PRIVATE cpuinfo_mock gtest)

--- a/scripts/android-arm64-mock.sh
+++ b/scripts/android-arm64-mock.sh
@@ -36,6 +36,7 @@ adb push build/android/arm64-v8a/pixel-c-test /data/local/tmp/pixel-c-test
 adb push build/android/arm64-v8a/pixel-xl-test /data/local/tmp/pixel-xl-test
 adb push build/android/arm64-v8a/pixel-test /data/local/tmp/pixel-test
 adb push build/android/arm64-v8a/pixel-2-xl-test /data/local/tmp/pixel-2-xl-test
+adb push build/android/arm64-v8a/pixel-8-test /data/local/tmp/pixel-8-test
 adb push build/android/arm64-v8a/xiaomi-mi-5c-test /data/local/tmp/xiaomi-mi-5c-test
 adb push build/android/arm64-v8a/xiaomi-redmi-note-3-test /data/local/tmp/xiaomi-redmi-note-3-test
 adb push build/android/arm64-v8a/xiaomi-redmi-note-4-test /data/local/tmp/xiaomi-redmi-note-4-test
@@ -75,6 +76,7 @@ adb shell "/data/local/tmp/pixel-c-test --gtest_color=yes"
 adb shell "/data/local/tmp/pixel-xl-test --gtest_color=yes"
 adb shell "/data/local/tmp/pixel-test --gtest_color=yes"
 adb shell "/data/local/tmp/pixel-2-xl-test --gtest_color=yes"
+adb shell "/data/local/tmp/pixel-8-test --gtest_color=yes"
 adb shell "/data/local/tmp/xiaomi-mi-5c-test --gtest_color=yes"
 adb shell "/data/local/tmp/xiaomi-redmi-note-3-test --gtest_color=yes"
 adb shell "/data/local/tmp/xiaomi-redmi-note-4-test --gtest_color=yes"

--- a/scripts/android-armv7-mock.sh
+++ b/scripts/android-armv7-mock.sh
@@ -70,6 +70,7 @@ adb push build/android/armeabi-v7a/pixel-c-test /data/local/tmp/pixel-c-test
 adb push build/android/armeabi-v7a/pixel-xl-test /data/local/tmp/pixel-xl-test
 adb push build/android/armeabi-v7a/pixel-test /data/local/tmp/pixel-test
 adb push build/android/armeabi-v7a/pixel-2-xl-test /data/local/tmp/pixel-2-xl-test
+adb push build/android/armeabi-v7a/pixel-8-test /data/local/tmp/pixel-8-test
 adb push build/android/armeabi-v7a/xiaomi-mi-5c-test /data/local/tmp/xiaomi-mi-5c-test
 adb push build/android/armeabi-v7a/xiaomi-redmi-2a-test /data/local/tmp/xiaomi-redmi-2a-test
 adb push build/android/armeabi-v7a/xiaomi-redmi-note-3-test /data/local/tmp/xiaomi-redmi-note-3-test
@@ -145,6 +146,7 @@ adb shell "/data/local/tmp/pixel-c-test --gtest_color=yes"
 adb shell "/data/local/tmp/pixel-xl-test --gtest_color=yes"
 adb shell "/data/local/tmp/pixel-test --gtest_color=yes"
 adb shell "/data/local/tmp/pixel-2-xl-test --gtest_color=yes"
+adb shell "/data/local/tmp/pixel-8-test --gtest_color=yes"
 adb shell "/data/local/tmp/xiaomi-mi-5c-test --gtest_color=yes"
 adb shell "/data/local/tmp/xiaomi-redmi-2a-test --gtest_color=yes"
 adb shell "/data/local/tmp/xiaomi-redmi-note-3-test --gtest_color=yes"

--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -333,13 +333,47 @@ void cpuinfo_arm_linux_init(void) {
 	}
 
 	/* Propagate topology group IDs among siblings */
+	bool detected_core_siblings_list_node = false;
+	bool detected_cluster_cpus_list_node = false;
 	for (uint32_t i = 0; i < arm_linux_processors_count; i++) {
 		if (!bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_VALID)) {
 			continue;
 		}
 
-		if (arm_linux_processors[i].flags & CPUINFO_LINUX_FLAG_PACKAGE_ID) {
+		if (!bitmask_all(arm_linux_processors[i].flags, CPUINFO_LINUX_FLAG_PACKAGE_ID)) {
+			continue;
+		}
+
+		/* Use the cluster_cpus_list topology node if available. If not
+		 * found, cache the result to avoid repeatedly attempting to
+		 * read the non-existent paths.
+		 * */
+		if (!detected_core_siblings_list_node && !detected_cluster_cpus_list_node) {
+			if (cpuinfo_linux_detect_cluster_cpus(
+				    arm_linux_processors_count,
+				    i,
+				    (cpuinfo_siblings_callback)cluster_siblings_parser,
+				    arm_linux_processors)) {
+				detected_cluster_cpus_list_node = true;
+				continue;
+			} else {
+				detected_core_siblings_list_node = true;
+			}
+		}
+
+		/* The cached result above will guarantee only one of the blocks
+		 * below will execute, with a bias towards cluster_cpus_list.
+		 **/
+		if (detected_core_siblings_list_node) {
 			cpuinfo_linux_detect_core_siblings(
+				arm_linux_processors_count,
+				i,
+				(cpuinfo_siblings_callback)cluster_siblings_parser,
+				arm_linux_processors);
+		}
+
+		if (detected_cluster_cpus_list_node) {
+			cpuinfo_linux_detect_cluster_cpus(
 				arm_linux_processors_count,
 				i,
 				(cpuinfo_siblings_callback)cluster_siblings_parser,

--- a/test/mock/pixel-8.cc
+++ b/test/mock/pixel-8.cc
@@ -1,0 +1,851 @@
+#include <gtest/gtest.h>
+
+#include <cpuinfo-mock.h>
+#include <cpuinfo.h>
+
+TEST(PROCESSORS, count) {
+	ASSERT_EQ(9, cpuinfo_get_processors_count());
+}
+
+TEST(PROCESSORS, non_null) {
+	ASSERT_TRUE(cpuinfo_get_processors());
+}
+
+TEST(PROCESSORS, smt_id) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_EQ(0, cpuinfo_get_processor(i)->smt_id);
+	}
+}
+
+TEST(PROCESSORS, core) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_EQ(cpuinfo_get_core(i), cpuinfo_get_processor(i)->core);
+	}
+}
+
+TEST(PROCESSORS, cluster) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(cpuinfo_get_cluster(0), cpuinfo_get_processor(i)->cluster);
+				break;
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+				ASSERT_EQ(cpuinfo_get_cluster(1), cpuinfo_get_processor(i)->cluster);
+				break;
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(cpuinfo_get_cluster(2), cpuinfo_get_processor(i)->cluster);
+				break;
+		}
+	}
+}
+
+TEST(PROCESSORS, package) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_EQ(cpuinfo_get_package(0), cpuinfo_get_processor(i)->package);
+	}
+}
+
+TEST(PROCESSORS, linux_id) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(8, cpuinfo_get_processor(i)->linux_id);
+				break;
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+				ASSERT_EQ(i + 3, cpuinfo_get_processor(i)->linux_id);
+				break;
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(i - 5, cpuinfo_get_processor(i)->linux_id);
+				break;
+		}
+	}
+}
+
+TEST(PROCESSORS, l1i) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_EQ(cpuinfo_get_l1i_cache(i), cpuinfo_get_processor(i)->cache.l1i);
+	}
+}
+
+TEST(PROCESSORS, l1d) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_EQ(cpuinfo_get_l1d_cache(i), cpuinfo_get_processor(i)->cache.l1d);
+	}
+}
+
+TEST(PROCESSORS, l2) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(cpuinfo_get_l2_cache(0), cpuinfo_get_processor(i)->cache.l2);
+				break;
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+				ASSERT_EQ(cpuinfo_get_l2_cache(1), cpuinfo_get_processor(i)->cache.l2);
+				break;
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(cpuinfo_get_l2_cache(2), cpuinfo_get_processor(i)->cache.l2);
+				break;
+		}
+	}
+}
+
+TEST(PROCESSORS, l3) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_FALSE(cpuinfo_get_processor(i)->cache.l3);
+	}
+}
+
+TEST(PROCESSORS, l4) {
+	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
+		ASSERT_FALSE(cpuinfo_get_processor(i)->cache.l4);
+	}
+}
+
+TEST(CORES, count) {
+	ASSERT_EQ(9, cpuinfo_get_cores_count());
+}
+
+TEST(CORES, non_null) {
+	ASSERT_TRUE(cpuinfo_get_cores());
+}
+
+TEST(CORES, processor_start) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		ASSERT_EQ(i, cpuinfo_get_core(i)->processor_start);
+	}
+}
+
+TEST(CORES, processor_count) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		ASSERT_EQ(1, cpuinfo_get_core(i)->processor_count);
+	}
+}
+
+TEST(CORES, core_id) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		ASSERT_EQ(i, cpuinfo_get_core(i)->core_id);
+	}
+}
+
+TEST(CORES, cluster) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(cpuinfo_get_cluster(0), cpuinfo_get_core(i)->cluster);
+				break;
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+				ASSERT_EQ(cpuinfo_get_cluster(1), cpuinfo_get_core(i)->cluster);
+				break;
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(cpuinfo_get_cluster(2), cpuinfo_get_core(i)->cluster);
+				break;
+		}
+	}
+}
+
+TEST(CORES, package) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		ASSERT_EQ(cpuinfo_get_package(0), cpuinfo_get_core(i)->package);
+	}
+}
+
+TEST(CORES, vendor) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		ASSERT_EQ(cpuinfo_vendor_arm, cpuinfo_get_core(i)->vendor);
+	}
+}
+
+TEST(CORES, uarch) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(cpuinfo_uarch_cortex_x3, cpuinfo_get_core(i)->uarch);
+				break;
+			case 1:
+			case 2:
+			case 3:
+				ASSERT_EQ(cpuinfo_uarch_cortex_a715, cpuinfo_get_core(i)->uarch);
+				break;
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(cpuinfo_uarch_cortex_a510, cpuinfo_get_core(i)->uarch);
+				break;
+		}
+	}
+}
+
+TEST(CORES, midr) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(UINT32_C(0x411fd4e0), cpuinfo_get_core(i)->midr);
+				break;
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+				ASSERT_EQ(UINT32_C(0x411fd4d0), cpuinfo_get_core(i)->midr);
+				break;
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(UINT32_C(0x411fd461), cpuinfo_get_core(i)->midr);
+				break;
+		}
+	}
+}
+
+TEST(CORES, DISABLED_frequency) {
+	for (uint32_t i = 0; i < cpuinfo_get_cores_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+			case 3:
+				ASSERT_EQ(UINT64_C(2457600000), cpuinfo_get_core(i)->frequency);
+				break;
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(UINT64_C(1900800000), cpuinfo_get_core(i)->frequency);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, count) {
+	ASSERT_EQ(3, cpuinfo_get_clusters_count());
+}
+
+TEST(CLUSTERS, non_null) {
+	ASSERT_TRUE(cpuinfo_get_clusters());
+}
+
+TEST(CLUSTERS, processor_start) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(0, cpuinfo_get_cluster(i)->processor_start);
+				break;
+			case 1:
+				ASSERT_EQ(1, cpuinfo_get_cluster(i)->processor_start);
+				break;
+			case 2:
+				ASSERT_EQ(5, cpuinfo_get_cluster(i)->processor_start);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, processor_count) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(1, cpuinfo_get_cluster(i)->processor_count);
+				break;
+			case 1:
+				ASSERT_EQ(4, cpuinfo_get_cluster(i)->processor_count);
+				break;
+			case 2:
+				ASSERT_EQ(4, cpuinfo_get_cluster(i)->processor_count);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, core_start) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(0, cpuinfo_get_cluster(i)->core_start);
+				break;
+			case 1:
+				ASSERT_EQ(1, cpuinfo_get_cluster(i)->core_start);
+				break;
+			case 2:
+				ASSERT_EQ(5, cpuinfo_get_cluster(i)->core_start);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, core_count) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(1, cpuinfo_get_cluster(i)->core_count);
+				break;
+			case 1:
+				ASSERT_EQ(4, cpuinfo_get_cluster(i)->core_count);
+				break;
+			case 2:
+				ASSERT_EQ(4, cpuinfo_get_cluster(i)->core_count);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, cluster_id) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		ASSERT_EQ(i, cpuinfo_get_cluster(i)->cluster_id);
+	}
+}
+
+TEST(CLUSTERS, package) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		ASSERT_EQ(cpuinfo_get_package(0), cpuinfo_get_cluster(i)->package);
+	}
+}
+
+TEST(CLUSTERS, vendor) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		ASSERT_EQ(cpuinfo_vendor_arm, cpuinfo_get_cluster(i)->vendor);
+	}
+}
+
+TEST(CLUSTERS, uarch) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(cpuinfo_uarch_cortex_x3, cpuinfo_get_cluster(i)->uarch);
+				break;
+			case 1:
+				ASSERT_EQ(cpuinfo_uarch_cortex_a715, cpuinfo_get_cluster(i)->uarch);
+				break;
+			case 2:
+				ASSERT_EQ(cpuinfo_uarch_cortex_a510, cpuinfo_get_cluster(i)->uarch);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, midr) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(UINT32_C(0x411fd4e0), cpuinfo_get_cluster(i)->midr);
+				break;
+			case 1:
+				ASSERT_EQ(UINT32_C(0x411fd4d0), cpuinfo_get_cluster(i)->midr);
+				break;
+			case 2:
+				ASSERT_EQ(UINT32_C(0x411fd461), cpuinfo_get_cluster(i)->midr);
+				break;
+		}
+	}
+}
+
+TEST(CLUSTERS, DISABLED_frequency) {
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+				ASSERT_EQ(UINT64_C(1197000), cpuinfo_get_cluster(i)->frequency);
+				break;
+		}
+	}
+}
+
+TEST(PACKAGES, count) {
+	ASSERT_EQ(1, cpuinfo_get_packages_count());
+}
+
+TEST(PACKAGES, name) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(
+			"Unknown",
+			std::string(
+				cpuinfo_get_package(i)->name,
+				strnlen(cpuinfo_get_package(i)->name, CPUINFO_PACKAGE_NAME_MAX)));
+	}
+}
+
+TEST(PACKAGES, processor_start) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(0, cpuinfo_get_package(i)->processor_start);
+	}
+}
+
+TEST(PACKAGES, processor_count) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(9, cpuinfo_get_package(i)->processor_count);
+	}
+}
+
+TEST(PACKAGES, core_start) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(0, cpuinfo_get_package(i)->core_start);
+	}
+}
+
+TEST(PACKAGES, core_count) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(9, cpuinfo_get_package(i)->core_count);
+	}
+}
+
+TEST(PACKAGES, cluster_start) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(0, cpuinfo_get_package(i)->cluster_start);
+	}
+}
+
+TEST(PACKAGES, cluster_count) {
+	for (uint32_t i = 0; i < cpuinfo_get_packages_count(); i++) {
+		ASSERT_EQ(3, cpuinfo_get_package(i)->cluster_count);
+	}
+}
+
+TEST(ISA, thumb) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_thumb());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_thumb());
+#endif
+}
+
+TEST(ISA, thumb2) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_thumb2());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_thumb2());
+#endif
+}
+
+TEST(ISA, armv5e) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_v5e());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_v5e());
+#endif
+}
+
+TEST(ISA, armv6) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_v6());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_v6());
+#endif
+}
+
+TEST(ISA, armv6k) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_v6k());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_v6k());
+#endif
+}
+
+TEST(ISA, armv7) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_v7());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_v7());
+#endif
+}
+
+TEST(ISA, armv7mp) {
+#if CPUINFO_ARCH_ARM
+	ASSERT_TRUE(cpuinfo_has_arm_v7mp());
+#elif CPUINFO_ARCH_ARM64
+	ASSERT_FALSE(cpuinfo_has_arm_v7mp());
+#endif
+}
+
+TEST(ISA, idiv) {
+	ASSERT_TRUE(cpuinfo_has_arm_idiv());
+}
+
+TEST(ISA, vfpv2) {
+	ASSERT_FALSE(cpuinfo_has_arm_vfpv2());
+}
+
+TEST(ISA, vfpv3) {
+	ASSERT_TRUE(cpuinfo_has_arm_vfpv3());
+}
+
+TEST(ISA, vfpv3_d32) {
+	ASSERT_TRUE(cpuinfo_has_arm_vfpv3_d32());
+}
+
+TEST(ISA, vfpv3_fp16) {
+	ASSERT_TRUE(cpuinfo_has_arm_vfpv3_fp16());
+}
+
+TEST(ISA, vfpv3_fp16_d32) {
+	ASSERT_TRUE(cpuinfo_has_arm_vfpv3_fp16_d32());
+}
+
+TEST(ISA, vfpv4) {
+	ASSERT_TRUE(cpuinfo_has_arm_vfpv4());
+}
+
+TEST(ISA, vfpv4_d32) {
+	ASSERT_TRUE(cpuinfo_has_arm_vfpv4_d32());
+}
+
+TEST(ISA, wmmx) {
+	ASSERT_FALSE(cpuinfo_has_arm_wmmx());
+}
+
+TEST(ISA, wmmx2) {
+	ASSERT_FALSE(cpuinfo_has_arm_wmmx2());
+}
+
+TEST(ISA, neon) {
+	ASSERT_TRUE(cpuinfo_has_arm_neon());
+}
+
+TEST(ISA, neon_fp16) {
+	ASSERT_TRUE(cpuinfo_has_arm_neon_fp16());
+}
+
+TEST(ISA, neon_fma) {
+	ASSERT_TRUE(cpuinfo_has_arm_neon_fma());
+}
+
+TEST(ISA, atomics) {
+	ASSERT_FALSE(cpuinfo_has_arm_atomics());
+}
+
+TEST(ISA, neon_rdm) {
+	ASSERT_FALSE(cpuinfo_has_arm_neon_rdm());
+}
+
+TEST(ISA, fp16_arith) {
+	ASSERT_FALSE(cpuinfo_has_arm_fp16_arith());
+}
+
+TEST(ISA, neon_fp16_arith) {
+	ASSERT_FALSE(cpuinfo_has_arm_neon_fp16_arith());
+}
+
+TEST(ISA, neon_dot) {
+	ASSERT_FALSE(cpuinfo_has_arm_neon_dot());
+}
+
+TEST(ISA, jscvt) {
+	ASSERT_FALSE(cpuinfo_has_arm_jscvt());
+}
+
+TEST(ISA, fcma) {
+	ASSERT_FALSE(cpuinfo_has_arm_fcma());
+}
+
+TEST(ISA, aes) {
+	ASSERT_TRUE(cpuinfo_has_arm_aes());
+}
+
+TEST(ISA, sha1) {
+	ASSERT_TRUE(cpuinfo_has_arm_sha1());
+}
+
+TEST(ISA, sha2) {
+	ASSERT_TRUE(cpuinfo_has_arm_sha2());
+}
+
+TEST(ISA, pmull) {
+	ASSERT_TRUE(cpuinfo_has_arm_pmull());
+}
+
+TEST(ISA, crc32) {
+	ASSERT_TRUE(cpuinfo_has_arm_crc32());
+}
+
+TEST(L1I, count) {
+	ASSERT_EQ(9, cpuinfo_get_l1i_caches_count());
+}
+
+TEST(L1I, non_null) {
+	ASSERT_TRUE(cpuinfo_get_l1i_caches());
+}
+
+TEST(L1I, size) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+			case 3:
+				ASSERT_EQ(64 * 512, cpuinfo_get_l1i_cache(i)->size);
+				break;
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(32 * 1024, cpuinfo_get_l1i_cache(i)->size);
+				break;
+		}
+	}
+}
+
+TEST(L1I, associativity) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(4, cpuinfo_get_l1i_cache(i)->associativity);
+				break;
+		}
+	}
+}
+
+TEST(L1I, sets) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		ASSERT_EQ(
+			cpuinfo_get_l1i_cache(i)->size,
+			cpuinfo_get_l1i_cache(i)->sets * cpuinfo_get_l1i_cache(i)->line_size *
+				cpuinfo_get_l1i_cache(i)->partitions * cpuinfo_get_l1i_cache(i)->associativity);
+	}
+}
+
+TEST(L1I, partitions) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		ASSERT_EQ(1, cpuinfo_get_l1i_cache(i)->partitions);
+	}
+}
+
+TEST(L1I, line_size) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		ASSERT_EQ(64, cpuinfo_get_l1i_cache(i)->line_size);
+	}
+}
+
+TEST(L1I, flags) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		ASSERT_EQ(0, cpuinfo_get_l1i_cache(i)->flags);
+	}
+}
+
+TEST(L1I, processors) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1i_caches_count(); i++) {
+		ASSERT_EQ(i, cpuinfo_get_l1i_cache(i)->processor_start);
+		ASSERT_EQ(1, cpuinfo_get_l1i_cache(i)->processor_count);
+	}
+}
+
+TEST(L1D, count) {
+	ASSERT_EQ(9, cpuinfo_get_l1d_caches_count());
+}
+
+TEST(L1D, non_null) {
+	ASSERT_TRUE(cpuinfo_get_l1d_caches());
+}
+
+TEST(L1D, size) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+			case 3:
+				ASSERT_EQ(64 * 512, cpuinfo_get_l1d_cache(i)->size);
+				break;
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(32 * 1024, cpuinfo_get_l1d_cache(i)->size);
+				break;
+		}
+	}
+}
+
+TEST(L1D, associativity) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+			case 3:
+			case 4:
+			case 5:
+			case 6:
+			case 7:
+			case 8:
+				ASSERT_EQ(4, cpuinfo_get_l1d_cache(i)->associativity);
+				break;
+		}
+	}
+}
+
+TEST(L1D, sets) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		ASSERT_EQ(
+			cpuinfo_get_l1d_cache(i)->size,
+			cpuinfo_get_l1d_cache(i)->sets * cpuinfo_get_l1d_cache(i)->line_size *
+				cpuinfo_get_l1d_cache(i)->partitions * cpuinfo_get_l1d_cache(i)->associativity);
+	}
+}
+
+TEST(L1D, partitions) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		ASSERT_EQ(1, cpuinfo_get_l1d_cache(i)->partitions);
+	}
+}
+
+TEST(L1D, line_size) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		ASSERT_EQ(64, cpuinfo_get_l1d_cache(i)->line_size);
+	}
+}
+
+TEST(L1D, flags) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		ASSERT_EQ(0, cpuinfo_get_l1d_cache(i)->flags);
+	}
+}
+
+TEST(L1D, processors) {
+	for (uint32_t i = 0; i < cpuinfo_get_l1d_caches_count(); i++) {
+		ASSERT_EQ(i, cpuinfo_get_l1d_cache(i)->processor_start);
+		ASSERT_EQ(1, cpuinfo_get_l1d_cache(i)->processor_count);
+	}
+}
+
+TEST(L2, count) {
+	ASSERT_EQ(3, cpuinfo_get_l2_caches_count());
+}
+
+TEST(L2, non_null) {
+	ASSERT_TRUE(cpuinfo_get_l2_caches());
+}
+
+TEST(L2, size) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(1 * 512 * 512, cpuinfo_get_l2_cache(i)->size);
+				break;
+			case 1:
+			case 2:
+				ASSERT_EQ(1 * 1024 * 1024, cpuinfo_get_l2_cache(i)->size);
+				break;
+		}
+	}
+}
+
+TEST(L2, associativity) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		ASSERT_EQ(8, cpuinfo_get_l2_cache(i)->associativity);
+	}
+}
+
+TEST(L2, sets) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		ASSERT_EQ(
+			cpuinfo_get_l2_cache(i)->size,
+			cpuinfo_get_l2_cache(i)->sets * cpuinfo_get_l2_cache(i)->line_size *
+				cpuinfo_get_l2_cache(i)->partitions * cpuinfo_get_l2_cache(i)->associativity);
+	}
+}
+
+TEST(L2, partitions) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		ASSERT_EQ(1, cpuinfo_get_l2_cache(i)->partitions);
+	}
+}
+
+TEST(L2, line_size) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		ASSERT_EQ(64, cpuinfo_get_l2_cache(i)->line_size);
+	}
+}
+
+TEST(L2, flags) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		switch (i) {
+			case 0:
+			case 1:
+			case 2:
+				ASSERT_EQ(0, cpuinfo_get_l2_cache(i)->flags);
+				break;
+		}
+	}
+}
+
+TEST(L2, processors) {
+	for (uint32_t i = 0; i < cpuinfo_get_l2_caches_count(); i++) {
+		switch (i) {
+			case 0:
+				ASSERT_EQ(0, cpuinfo_get_l2_cache(i)->processor_start);
+				ASSERT_EQ(1, cpuinfo_get_l2_cache(i)->processor_count);
+				break;
+			case 1:
+				ASSERT_EQ(1, cpuinfo_get_l2_cache(i)->processor_start);
+				ASSERT_EQ(4, cpuinfo_get_l2_cache(i)->processor_count);
+				break;
+			case 2:
+				ASSERT_EQ(5, cpuinfo_get_l2_cache(i)->processor_start);
+				ASSERT_EQ(4, cpuinfo_get_l2_cache(i)->processor_count);
+				break;
+		}
+	}
+}
+
+TEST(L3, none) {
+	ASSERT_EQ(0, cpuinfo_get_l3_caches_count());
+	ASSERT_FALSE(cpuinfo_get_l3_caches());
+}
+
+TEST(L4, none) {
+	ASSERT_EQ(0, cpuinfo_get_l4_caches_count());
+	ASSERT_FALSE(cpuinfo_get_l4_caches());
+}
+
+#include <pixel-8.h>
+
+int main(int argc, char* argv[]) {
+#if CPUINFO_ARCH_ARM
+	cpuinfo_set_hwcap(UINT32_C(0x0037B0D6));
+	cpuinfo_set_hwcap2(UINT32_C(0x0000001F));
+#elif CPUINFO_ARCH_ARM64
+	cpuinfo_set_hwcap(UINT32_C(0x000000FF));
+#endif
+	cpuinfo_mock_filesystem(filesystem);
+#ifdef __ANDROID__
+	cpuinfo_mock_android_properties(properties);
+#endif
+	cpuinfo_initialize();
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/test/mock/pixel-8.h
+++ b/test/mock/pixel-8.h
@@ -1,0 +1,1294 @@
+struct cpuinfo_mock_file filesystem[] = {
+	{.path = "/proc/cpuinfo",
+	 .size = 3717,
+	 .content =
+		 "processor\t: 0\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd46\n"
+		 "CPU revision\t: 1\n"
+		 "\n"
+		 "processor\t: 1\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd46\n"
+		 "CPU revision\t: 1\n"
+		 "\n"
+		 "processor\t: 2\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd46\n"
+		 "CPU revision\t: 1\n"
+		 "\n"
+		 "processor\t: 3\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd46\n"
+		 "CPU revision\t: 1\n"
+		 "\n"
+		 "processor\t: 4\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd4d\n"
+		 "CPU revision\t: 0\n"
+		 "\n"
+		 "processor\t: 5\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd4d\n"
+		 "CPU revision\t: 0\n"
+		 "\n"
+		 "processor\t: 6\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd4d\n"
+		 "CPU revision\t: 0\n"
+		 "\n"
+		 "processor\t: 7\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd4d\n"
+		 "CPU revision\t: 0\n"
+		 "\n"
+		 "processor\t: 8\n"
+		 "BogoMIPS\t: 49.15\n"
+		 "Features\t: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 sve asimdfhm dit uscat ilrcpc flagm ssbs sb paca pacg dcpodp sve2 sveaes svepmull svebitperm svesha3 svesm4 flagm2 frint svei8mm svebf16 i8mm bti\n"
+		 "CPU implementer\t: 0x41\n"
+		 "CPU architecture: 8\n"
+		 "CPU variant\t: 0x1\n"
+		 "CPU part\t: 0xd4e\n"
+		 "CPU revision\t: 0\n"},
+	{.path = "/sys/devices/system/cpu/kernel_max", .size = 3, .content = "31\n"},
+	{.path = "/sys/devices/system/cpu/possible", .size = 4, .content = "0-8\n"},
+	{.path = "/sys/devices/system/cpu/present", .size = 4, .content = "0-8\n"},
+	{.path = "/sys/devices/system/cpu/online", .size = 4, .content = "0-8\n"},
+	{.path = "/sys/devices/system/cpu/offline", .size = 1, .content = "\n"},
+	{.path = "/sys/devices/system/cpu/modalias",
+	 .size = 251,
+	 .content =
+		 "cpu:type:aarch64:feature:,0000,0001,0002,0003,0004,0005,0006,0007,0008,0009,000A,000B,000C,000D,000E,000F,0010,0011,0012,0013,0014,0015,0016,0017,0018,0019,001A,001B,001C,001D,001E,001F,0020,0021,0022,0023,0024,0025,0026,0027,0028,0029,002C,002D,0031\n"},
+	{.path = "/sys/devices/system/cpu/cpuidle/current_driver", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpuidle/current_governor_ro", .size = 4, .content = "teo\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/affected_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq", .size = 8, .content = "1704000\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/related_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_frequencies",
+	 .size = 76,
+	 .content = "324000 610000 820000 955000 1098000 1197000 1328000 1425000 1548000 1704000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", .size = 8, .content = "1197000\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state",
+	 .size = 131,
+	 .content = "324000 1026376\n"
+		    "610000 18555\n"
+		    "820000 12889\n"
+		    "955000 3943\n"
+		    "1098000 4202\n"
+		    "1197000 2559\n"
+		    "1328000 4948\n"
+		    "1425000 1421\n"
+		    "1548000 1288\n"
+		    "1704000 9901\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/cpufreq/stats/total_trans", .size = 7, .content = "115798\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/core_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/core_siblings_list", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/cluster_cpus", .size = 4, .content = "00f\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/cluster_cpus_list", .size = 4, .content = "0-3\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/physical_package_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/thread_siblings", .size = 4, .content = "001\n"},
+	{.path = "/sys/devices/system/cpu/cpu0/topology/thread_siblings_list", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/affected_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq", .size = 8, .content = "1704000\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/related_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/scaling_available_frequencies",
+	 .size = 76,
+	 .content = "324000 610000 820000 955000 1098000 1197000 1328000 1425000 1548000 1704000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/scaling_cur_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/scaling_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/stats/time_in_state",
+	 .size = 131,
+	 .content = "324000 1027068\n"
+		    "610000 18568\n"
+		    "820000 12892\n"
+		    "955000 3945\n"
+		    "1098000 4212\n"
+		    "1197000 2563\n"
+		    "1328000 4950\n"
+		    "1425000 1422\n"
+		    "1548000 1288\n"
+		    "1704000 9910\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/cpufreq/stats/total_trans", .size = 7, .content = "115912\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/core_id", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/core_siblings_list", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/cluster_cpus", .size = 4, .content = "00f\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/cluster_cpus_list", .size = 4, .content = "0-3\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/physical_package_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/thread_siblings", .size = 4, .content = "002\n"},
+	{.path = "/sys/devices/system/cpu/cpu1/topology/thread_siblings_list", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/affected_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_max_freq", .size = 8, .content = "1704000\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/related_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/scaling_available_frequencies",
+	 .size = 76,
+	 .content = "324000 610000 820000 955000 1098000 1197000 1328000 1425000 1548000 1704000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/scaling_cur_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/scaling_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/stats/time_in_state",
+	 .size = 131,
+	 .content = "324000 1027745\n"
+		    "610000 18580\n"
+		    "820000 12909\n"
+		    "955000 3950\n"
+		    "1098000 4217\n"
+		    "1197000 2570\n"
+		    "1328000 4958\n"
+		    "1425000 1423\n"
+		    "1548000 1290\n"
+		    "1704000 9923\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/cpufreq/stats/total_trans", .size = 7, .content = "116054\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/core_id", .size = 2, .content = "2\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/core_siblings_list", .size = 2, .content = "2\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/cluster_cpus", .size = 4, .content = "00f\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/cluster_cpus_list", .size = 4, .content = "0-3\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/physical_package_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/thread_siblings", .size = 4, .content = "004\n"},
+	{.path = "/sys/devices/system/cpu/cpu2/topology/thread_siblings_list", .size = 2, .content = "2\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/affected_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_max_freq", .size = 8, .content = "1704000\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/related_cpus", .size = 8, .content = "0 1 2 3\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/scaling_available_frequencies",
+	 .size = 76,
+	 .content = "324000 610000 820000 955000 1098000 1197000 1328000 1425000 1548000 1704000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/scaling_cur_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/scaling_min_freq", .size = 7, .content = "324000\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/stats/time_in_state",
+	 .size = 131,
+	 .content = "324000 1028434\n"
+		    "610000 18597\n"
+		    "820000 12919\n"
+		    "955000 3952\n"
+		    "1098000 4223\n"
+		    "1197000 2577\n"
+		    "1328000 4960\n"
+		    "1425000 1424\n"
+		    "1548000 1290\n"
+		    "1704000 9931\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/cpufreq/stats/total_trans", .size = 7, .content = "116188\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/core_id", .size = 2, .content = "3\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/core_siblings_list", .size = 2, .content = "3\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/cluster_cpus", .size = 4, .content = "00f\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/cluster_cpus_list", .size = 4, .content = "0-3\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/physical_package_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/thread_siblings", .size = 4, .content = "008\n"},
+	{.path = "/sys/devices/system/cpu/cpu3/topology/thread_siblings_list", .size = 2, .content = "3\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/affected_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/cpuinfo_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/cpuinfo_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/related_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_available_frequencies",
+	 .size = 115,
+	 .content =
+		 "402000 578000 697000 712000 910000 1065000 1221000 1328000 1418000 1572000 1836000 1945000 2130000 2245000 2367000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq", .size = 8, .content = "2130000\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/stats/time_in_state",
+	 .size = 194,
+	 .content = "402000 1023353\n"
+		    "578000 3901\n"
+		    "697000 2240\n"
+		    "712000 282\n"
+		    "910000 8163\n"
+		    "1065000 2924\n"
+		    "1221000 2351\n"
+		    "1328000 1368\n"
+		    "1418000 1272\n"
+		    "1572000 6658\n"
+		    "1836000 12747\n"
+		    "1945000 4128\n"
+		    "2130000 2880\n"
+		    "2245000 1570\n"
+		    "2367000 15230\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/cpufreq/stats/total_trans", .size = 6, .content = "62643\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/core_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/core_siblings_list", .size = 2, .content = "4\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/cluster_cpus", .size = 4, .content = "0f0\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/cluster_cpus_list", .size = 4, .content = "4-7\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/physical_package_id", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/thread_siblings", .size = 4, .content = "010\n"},
+	{.path = "/sys/devices/system/cpu/cpu4/topology/thread_siblings_list", .size = 2, .content = "4\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/affected_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/cpuinfo_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/cpuinfo_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/related_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_available_frequencies",
+	 .size = 115,
+	 .content =
+		 "402000 578000 697000 712000 910000 1065000 1221000 1328000 1418000 1572000 1836000 1945000 2130000 2245000 2367000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_cur_freq", .size = 8, .content = "1945000\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/stats/time_in_state",
+	 .size = 194,
+	 .content = "402000 1023895\n"
+		    "578000 3911\n"
+		    "697000 2240\n"
+		    "712000 282\n"
+		    "910000 8163\n"
+		    "1065000 2924\n"
+		    "1221000 2355\n"
+		    "1328000 1368\n"
+		    "1418000 1272\n"
+		    "1572000 6684\n"
+		    "1836000 12823\n"
+		    "1945000 4147\n"
+		    "2130000 2894\n"
+		    "2245000 1571\n"
+		    "2367000 15301\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/cpufreq/stats/total_trans", .size = 6, .content = "62928\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/core_id", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/core_siblings_list", .size = 2, .content = "5\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/cluster_cpus", .size = 4, .content = "0f0\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/cluster_cpus_list", .size = 4, .content = "4-7\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/physical_package_id", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/thread_siblings", .size = 4, .content = "020\n"},
+	{.path = "/sys/devices/system/cpu/cpu5/topology/thread_siblings_list", .size = 2, .content = "5\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/affected_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/cpuinfo_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/cpuinfo_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/related_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_available_frequencies",
+	 .size = 115,
+	 .content =
+		 "402000 578000 697000 712000 910000 1065000 1221000 1328000 1418000 1572000 1836000 1945000 2130000 2245000 2367000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_cur_freq", .size = 8, .content = "1945000\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/stats/time_in_state",
+	 .size = 194,
+	 .content = "402000 1024410\n"
+		    "578000 3922\n"
+		    "697000 2240\n"
+		    "712000 282\n"
+		    "910000 8163\n"
+		    "1065000 2924\n"
+		    "1221000 2355\n"
+		    "1328000 1368\n"
+		    "1418000 1277\n"
+		    "1572000 6718\n"
+		    "1836000 12892\n"
+		    "1945000 4164\n"
+		    "2130000 2901\n"
+		    "2245000 1571\n"
+		    "2367000 15400\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/cpufreq/stats/total_trans", .size = 6, .content = "63222\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/core_id", .size = 2, .content = "2\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/core_siblings_list", .size = 2, .content = "6\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/cluster_cpus", .size = 4, .content = "0f0\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/cluster_cpus_list", .size = 4, .content = "4-7\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/physical_package_id", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/thread_siblings", .size = 4, .content = "040\n"},
+	{.path = "/sys/devices/system/cpu/cpu6/topology/thread_siblings_list", .size = 2, .content = "6\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/affected_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/cpuinfo_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/cpuinfo_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/related_cpus", .size = 8, .content = "4 5 6 7\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_available_frequencies",
+	 .size = 115,
+	 .content =
+		 "402000 578000 697000 712000 910000 1065000 1221000 1328000 1418000 1572000 1836000 1945000 2130000 2245000 2367000 \n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_cur_freq", .size = 8, .content = "2130000\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_max_freq", .size = 8, .content = "2367000\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq", .size = 7, .content = "402000\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/stats/time_in_state",
+	 .size = 194,
+	 .content = "402000 1024939\n"
+		    "578000 3931\n"
+		    "697000 2242\n"
+		    "712000 282\n"
+		    "910000 8170\n"
+		    "1065000 2925\n"
+		    "1221000 2355\n"
+		    "1328000 1368\n"
+		    "1418000 1277\n"
+		    "1572000 6747\n"
+		    "1836000 12967\n"
+		    "1945000 4185\n"
+		    "2130000 2918\n"
+		    "2245000 1571\n"
+		    "2367000 15468\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/cpufreq/stats/total_trans", .size = 6, .content = "63514\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/core_id", .size = 2, .content = "3\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/core_siblings_list", .size = 2, .content = "7\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/cluster_cpus", .size = 4, .content = "0f0\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/cluster_cpus_list", .size = 4, .content = "4-7\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/physical_package_id", .size = 2, .content = "1\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/thread_siblings", .size = 4, .content = "080\n"},
+	{.path = "/sys/devices/system/cpu/cpu7/topology/thread_siblings_list", .size = 2, .content = "7\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpuidle/driver/name", .size = 10, .content = "psci_idle\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/affected_cpus", .size = 2, .content = "8\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/cpuinfo_max_freq", .size = 8, .content = "2914000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/cpuinfo_min_freq", .size = 7, .content = "500000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/cpuinfo_transition_latency", .size = 8, .content = "5000000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/related_cpus", .size = 2, .content = "8\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_available_frequencies",
+	 .size = 115,
+	 .content =
+		 "500000 880000 1164000 1298000 1557000 1745000 1885000 2049000 2147000 2294000 2363000 2556000 2687000 2850000 2914000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_available_governors",
+	 .size = 57,
+	 .content = "sched_pixel conservative powersave performance schedutil \n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_cur_freq", .size = 7, .content = "500000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_driver", .size = 15, .content = "exynos_cpufreq\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_governor", .size = 12, .content = "sched_pixel\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_max_freq", .size = 8, .content = "2914000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/scaling_min_freq", .size = 7, .content = "500000\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/stats/time_in_state",
+	 .size = 188,
+	 .content = "500000 1530909\n"
+		    "880000 3209\n"
+		    "1164000 1553\n"
+		    "1298000 885\n"
+		    "1557000 2004\n"
+		    "1745000 1410\n"
+		    "1885000 631\n"
+		    "2049000 4090\n"
+		    "2147000 278\n"
+		    "2294000 522\n"
+		    "2363000 228\n"
+		    "2556000 525\n"
+		    "2687000 311\n"
+		    "2850000 940\n"
+		    "2914000 3929\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/cpufreq/stats/total_trans", .size = 6, .content = "18185\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/core_id", .size = 2, .content = "0\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/core_siblings_list", .size = 2, .content = "8\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/cluster_cpus", .size = 4, .content = "f00\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/cluster_cpus_list", .size = 2, .content = "8\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/physical_package_id", .size = 2, .content = "2\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/thread_siblings", .size = 4, .content = "100\n"},
+	{.path = "/sys/devices/system/cpu/cpu8/topology/thread_siblings_list", .size = 2, .content = "8\n"},
+	{NULL},
+};
+#ifdef __ANDROID__
+struct cpuinfo_mock_property properties[] = {
+	{
+		.key = "aaudio.hw_burst_min_usec",
+		.value = "2000",
+	},
+	{
+		.key = "aaudio.mmap_exclusive_policy",
+		.value = "2",
+	},
+	{
+		.key = "aaudio.mmap_policy",
+		.value = "2",
+	},
+	{
+		.key = "dalvik.vm.appimageformat",
+		.value = "lz4",
+	},
+	{
+		.key = "dalvik.vm.dex2oat-Xms",
+		.value = "64m",
+	},
+	{
+		.key = "dalvik.vm.dex2oat-Xmx",
+		.value = "512m",
+	},
+	{
+		.key = "dalvik.vm.dexopt.secondary",
+		.value = "true",
+	},
+	{
+		.key = "dalvik.vm.heapgrowthlimit",
+		.value = "256m",
+	},
+	{
+		.key = "dalvik.vm.heapmaxfree",
+		.value = "32m",
+	},
+	{
+		.key = "dalvik.vm.heapminfree",
+		.value = "8m",
+	},
+	{
+		.key = "dalvik.vm.heapsize",
+		.value = "512m",
+	},
+	{
+		.key = "dalvik.vm.heapstartsize",
+		.value = "16m",
+	},
+	{
+		.key = "dalvik.vm.heaptargetutilization",
+		.value = "0.5",
+	},
+	{
+		.key = "dalvik.vm.image-dex2oat-Xms",
+		.value = "64m",
+	},
+	{
+		.key = "dalvik.vm.image-dex2oat-Xmx",
+		.value = "64m",
+	},
+	{
+		.key = "dalvik.vm.isa.arm64.features",
+		.value = "default",
+	},
+	{
+		.key = "dalvik.vm.isa.arm64.variant",
+		.value = "cortex-a55",
+	},
+	{
+		.key = "dalvik.vm.usejit",
+		.value = "true",
+	},
+	{
+		.key = "debug.atrace.tags.enableflags",
+		.value = "0",
+	},
+	{
+		.key = "debug.force_rtl",
+		.value = "false",
+	},
+	{
+		.key = "dev.bootcomplete",
+		.value = "1",
+	},
+	{
+		.key = "drm.service.enabled",
+		.value = "true",
+	},
+	{
+		.key = "gsm.current.phone-type",
+		.value = "1,1",
+	},
+	{
+		.key = "gsm.network.type",
+		.value = "IWLAN,IWLAN",
+	},
+	{
+		.key = "gsm.operator.alpha",
+		.value = ",",
+	},
+	{
+		.key = "gsm.operator.iso-country",
+		.value = "us,",
+	},
+	{
+		.key = "gsm.operator.isroaming",
+		.value = "false,false",
+	},
+	{
+		.key = "gsm.operator.numeric",
+		.value = ",",
+	},
+	{
+		.key = "gsm.sim.operator.alpha",
+		.value = ",",
+	},
+	{
+		.key = "gsm.sim.operator.iso-country",
+		.value = ",",
+	},
+	{
+		.key = "gsm.sim.operator.numeric",
+		.value = ",",
+	},
+	{
+		.key = "gsm.sim.state",
+		.value = "ABSENT,NOT_READY",
+	},
+	{
+		.key = "gsm.version.baseband",
+		.value = "g5300i-230927-231102-B-11040898,g5300i-230927-231102-B-11040898",
+	},
+	{
+		.key = "gsm.version.ril-impl",
+		.value = "Samsung S.LSI Vendor RIL V2.3 Build 2023-12-12 01:31:33",
+	},
+	{
+		.key = "hwservicemanager.ready",
+		.value = "true",
+	},
+	{
+		.key = "init.svc.adbd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.audioserver",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.bootanim",
+		.value = "stopped",
+	},
+	{
+		.key = "init.svc.cameraserver",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.drm",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.gatekeeperd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.gnss_service",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.hidl_memory",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.hwservicemanager",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.init-radio-sh",
+		.value = "stopped",
+	},
+	{
+		.key = "init.svc.insmod_sh",
+		.value = "stopped",
+	},
+	{
+		.key = "init.svc.installd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.lmkd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.logd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.logd-reinit",
+		.value = "stopped",
+	},
+	{
+		.key = "init.svc.media",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.mediadrm",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.mediaextractor",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.mediametrics",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.netd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.nfc_hal_service",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.ril-daemon",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.servicemanager",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.storaged",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.surfaceflinger",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.tombstoned",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.ueventd",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.update_engine",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.update_verifier_nonencrypted",
+		.value = "stopped",
+	},
+	{
+		.key = "init.svc.vndservicemanager",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.vold",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.wificond",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.wpa_supplicant",
+		.value = "running",
+	},
+	{
+		.key = "init.svc.zygote",
+		.value = "running",
+	},
+	{
+		.key = "keyguard.no_require_sim",
+		.value = "true",
+	},
+	{
+		.key = "media.mediadrmservice.enable",
+		.value = "true",
+	},
+	{
+		.key = "net.bt.name",
+		.value = "Android",
+	},
+	{
+		.key = "nfc.initialized",
+		.value = "true",
+	},
+	{
+		.key = "partition.system.verified",
+		.value = "2",
+	},
+	{
+		.key = "partition.vendor.verified",
+		.value = "2",
+	},
+	{
+		.key = "persist.sys.dalvik.vm.lib.2",
+		.value = "libart.so",
+	},
+	{
+		.key = "persist.sys.sf.color_saturation",
+		.value = "1.0",
+	},
+	{
+		.key = "persist.sys.timezone",
+		.value = "America/Los_Angeles",
+	},
+	{
+		.key = "persist.sys.usb.config",
+		.value = "adb",
+	},
+	{
+		.key = "pm.dexopt.ab-ota",
+		.value = "speed-profile",
+	},
+	{
+		.key = "pm.dexopt.bg-dexopt",
+		.value = "speed-profile",
+	},
+	{
+		.key = "pm.dexopt.first-boot",
+		.value = "verify",
+	},
+	{
+		.key = "pm.dexopt.inactive",
+		.value = "verify",
+	},
+	{
+		.key = "pm.dexopt.install",
+		.value = "speed-profile",
+	},
+	{
+		.key = "pm.dexopt.shared",
+		.value = "speed",
+	},
+	{
+		.key = "ro.adb.secure",
+		.value = "1",
+	},
+	{
+		.key = "ro.allow.mock.location",
+		.value = "0",
+	},
+	{
+		.key = "ro.atrace.core.services",
+		.value = "com.google.android.gms,com.google.android.gms.ui,com.google.android.gms.persistent",
+	},
+	{
+		.key = "ro.audio.monitorRotation",
+		.value = "true",
+	},
+	{
+		.key = "ro.baseband",
+		.value = "unknown",
+	},
+	{
+		.key = "ro.board.platform",
+		.value = "zuma",
+	},
+	{
+		.key = "ro.boot.avb_version",
+		.value = "1.2",
+	},
+	{
+		.key = "ro.boot.bootdevice",
+		.value = "13200000.ufs",
+	},
+	{
+		.key = "ro.boot.bootloader",
+		.value = "ripcurrent-14.1-11012321",
+	},
+	{
+		.key = "ro.boot.bootreason",
+		.value = "reboot",
+	},
+	{
+		.key = "ro.boot.boottime",
+		.value =
+			"0BLE:112,1BLL:7,1BLE:73,2BLL:28,2BLE:557,3BLL:314,3BLE:194,SW:10058,KL:13,KD:0,ODT:62,AVB:96,FWL:149",
+	},
+	{
+		.key = "ro.boot.ddr_info",
+		.value = "Micron",
+	},
+	{
+		.key = "ro.boot.ddr_size",
+		.value = "8GiB",
+	},
+	{
+		.key = "ro.boot.flash.locked",
+		.value = "0",
+	},
+	{
+		.key = "ro.boot.hardware",
+		.value = "shiba",
+	},
+	{
+		.key = "ro.boot.hardware.color",
+		.value = "HAZ",
+	},
+	{
+		.key = "ro.boot.hardware.revision",
+		.value = "MP1.0",
+	},
+	{
+		.key = "ro.boot.hardware.sku",
+		.value = "G9BQD",
+	},
+	{
+		.key = "ro.boot.hardware.ufs",
+		.value = "128GB,Micron",
+	},
+	{
+		.key = "ro.boot.revision",
+		.value = "MP1.0",
+	},
+	{
+		.key = "ro.boot.serialno",
+		.value = "39061FDJH005AB",
+	},
+	{
+		.key = "ro.boot.slot_suffix",
+		.value = "_a",
+	},
+	{
+		.key = "ro.boot.vbmeta.avb_version",
+		.value = "1.2",
+	},
+	{
+		.key = "ro.boot.vbmeta.device_state",
+		.value = "unlocked",
+	},
+	{
+		.key = "ro.boot.vbmeta.digest",
+		.value = "64384054dbd4c6c629c119818f784bf515a4a9996c14f3bb7b314a6267fc7706",
+	},
+	{
+		.key = "ro.boot.vbmeta.hash_alg",
+		.value = "sha256",
+	},
+	{
+		.key = "ro.boot.vbmeta.size",
+		.value = "16512",
+	},
+	{
+		.key = "ro.boot.verifiedbootstate",
+		.value = "orange",
+	},
+	{
+		.key = "ro.boot.veritymode",
+		.value = "enforcing",
+	},
+	{
+		.key = "ro.boot.wificountrycode",
+		.value = "00",
+	},
+	{
+		.key = "ro.bootimage.build.date",
+		.value = "Tue Dec 12 05:18:54 UTC 2023",
+	},
+	{
+		.key = "ro.bootimage.build.date.utc",
+		.value = "1702358334",
+	},
+	{
+		.key = "ro.bootimage.build.fingerprint",
+		.value = "google/shiba/shiba:14/UQ1A.240105.004/11206848:userdebug/dev-keys",
+	},
+	{
+		.key = "ro.bootloader",
+		.value = "ripcurrent-14.1-11012321",
+	},
+	{
+		.key = "ro.bootmode",
+		.value = "unknown",
+	},
+	{
+		.key = "ro.build.ab_update",
+		.value = "true",
+	},
+	{
+		.key = "ro.build.characteristics",
+		.value = "nosdcard",
+	},
+	{
+		.key = "ro.build.date",
+		.value = "Tue Dec 12 05:18:54 UTC 2023",
+	},
+	{
+		.key = "ro.build.date.utc",
+		.value = "1702358334",
+	},
+	{
+		.key = "ro.build.description",
+		.value = "shiba-userdebug 14 UQ1A.240105.004 11206848 dev-keys",
+	},
+	{
+		.key = "ro.build.display.id",
+		.value = "shiba-userdebug 14 UQ1A.240105.004 11206848 dev-keys",
+	},
+	{
+		.key = "ro.build.expect.baseband",
+		.value = "g5300i-230927-231102-B-11040898",
+	},
+	{
+		.key = "ro.build.expect.bootloader",
+		.value = "ripcurrent-14.1-11012321",
+	},
+	{
+		.key = "ro.build.fingerprint",
+		.value = "google/shiba/shiba:14/UQ1A.240105.004/11206848:userdebug/dev-keys",
+	},
+	{
+		.key = "ro.build.flavor",
+		.value = "shiba-userdebug",
+	},
+	{
+		.key = "ro.build.host",
+		.value = "abfarm-release-rbe-32-2004-00107",
+	},
+	{
+		.key = "ro.build.id",
+		.value = "UQ1A.240105.004",
+	},
+	{
+		.key = "ro.build.product",
+		.value = "shiba",
+	},
+	{
+		.key = "ro.build.tags",
+		.value = "dev-keys",
+	},
+	{
+		.key = "ro.build.type",
+		.value = "userdebug",
+	},
+	{
+		.key = "ro.build.user",
+		.value = "android-build",
+	},
+	{
+		.key = "ro.build.version.all_codenames",
+		.value = "REL",
+	},
+	{
+		.key = "ro.build.version.codename",
+		.value = "REL",
+	},
+	{
+		.key = "ro.build.version.incremental",
+		.value = "11206848",
+	},
+	{
+		.key = "ro.build.version.preview_sdk",
+		.value = "0",
+	},
+	{
+		.key = "ro.build.version.release",
+		.value = "14",
+	},
+	{
+		.key = "ro.build.version.sdk",
+		.value = "34",
+	},
+	{
+		.key = "ro.build.version.security_patch",
+		.value = "2024-01-05",
+	},
+	{
+		.key = "ro.carrier",
+		.value = "unknown",
+	},
+	{
+		.key = "ro.com.android.dataroaming",
+		.value = "false",
+	},
+	{
+		.key = "ro.com.android.prov_mobiledata",
+		.value = "false",
+	},
+	{
+		.key = "ro.com.google.clientidbase",
+		.value = "android-google",
+	},
+	{
+		.key = "ro.com.google.ime.theme_id",
+		.value = "5",
+	},
+	{
+		.key = "ro.config.alarm_alert",
+		.value = "Fresh_start.ogg",
+	},
+	{
+		.key = "ro.config.media_vol_steps",
+		.value = "25",
+	},
+	{
+		.key = "ro.config.notification_sound",
+		.value = "Eureka.ogg",
+	},
+	{
+		.key = "ro.config.ringtone",
+		.value = "Your_new_adventure.ogg",
+	},
+	{
+		.key = "ro.config.vc_call_vol_steps",
+		.value = "7",
+	},
+	{
+		.key = "ro.control_privapp_permissions",
+		.value = "enforce",
+	},
+	{
+		.key = "ro.crypto.state",
+		.value = "encrypted",
+	},
+	{
+		.key = "ro.crypto.type",
+		.value = "file",
+	},
+	{
+		.key = "ro.dalvik.vm.native.bridge",
+		.value = "0",
+	},
+	{
+		.key = "ro.debuggable",
+		.value = "1",
+	},
+	{
+		.key = "ro.error.receiver.system.apps",
+		.value = "com.google.android.gms",
+	},
+	{
+		.key = "ro.frp.pst",
+		.value = "/dev/block/by-name/frp",
+	},
+	{
+		.key = "ro.hardware",
+		.value = "shiba",
+	},
+	{
+		.key = "ro.oem_unlock_supported",
+		.value = "1",
+	},
+	{
+		.key = "ro.opa.eligible_device",
+		.value = "true",
+	},
+	{
+		.key = "ro.opengles.version",
+		.value = "196610",
+	},
+	{
+		.key = "ro.product.board",
+		.value = "shiba",
+	},
+	{
+		.key = "ro.product.brand",
+		.value = "google",
+	},
+	{
+		.key = "ro.product.cpu.abi",
+		.value = "arm64-v8a",
+	},
+	{
+		.key = "ro.product.cpu.abilist",
+		.value = "arm64-v8a",
+	},
+	{
+		.key = "ro.product.cpu.abilist64",
+		.value = "arm64-v8a",
+	},
+	{
+		.key = "ro.product.device",
+		.value = "shiba",
+	},
+	{
+		.key = "ro.product.first_api_level",
+		.value = "34",
+	},
+	{
+		.key = "ro.product.locale",
+		.value = "en-US",
+	},
+	{
+		.key = "ro.product.manufacturer",
+		.value = "Google",
+	},
+	{
+		.key = "ro.product.model",
+		.value = "Pixel 8",
+	},
+	{
+		.key = "ro.product.name",
+		.value = "shiba",
+	},
+	{
+		.key = "ro.property_service.version",
+		.value = "2",
+	},
+	{
+		.key = "ro.revision",
+		.value = "MP1.0",
+	},
+	{
+		.key = "ro.secure",
+		.value = "1",
+	},
+	{
+		.key = "ro.serialno",
+		.value = "39061FDJH005AB",
+	},
+	{
+		.key = "ro.setupwizard.enterprise_mode",
+		.value = "1",
+	},
+	{
+		.key = "ro.setupwizard.esim_cid_ignore",
+		.value = "00000001",
+	},
+	{
+		.key = "ro.sf.lcd_density",
+		.value = "420",
+	},
+	{
+		.key = "ro.storage_manager.enabled",
+		.value = "false",
+	},
+	{
+		.key = "ro.telephony.default_network",
+		.value = "27",
+	},
+	{
+		.key = "ro.treble.enabled",
+		.value = "true",
+	},
+	{
+		.key = "ro.vendor.build.date",
+		.value = "Tue Dec 12 05:18:54 UTC 2023",
+	},
+	{
+		.key = "ro.vendor.build.date.utc",
+		.value = "1702358334",
+	},
+	{
+		.key = "ro.vendor.build.fingerprint",
+		.value = "google/shiba/shiba:14/UQ1A.240105.004/11206848:userdebug/dev-keys",
+	},
+	{
+		.key = "ro.zygote",
+		.value = "zygote64",
+	},
+	{
+		.key = "security.perf_harden",
+		.value = "1",
+	},
+	{
+		.key = "selinux.restorecon_recursive",
+		.value = "/data/misc_ce/0",
+	},
+	{
+		.key = "service.bootanim.exit",
+		.value = "1",
+	},
+	{
+		.key = "service.sf.present_timestamp",
+		.value = "1",
+	},
+	{
+		.key = "setupwizard.theme",
+		.value = "glif_v4_light",
+	},
+	{
+		.key = "sys.boot_completed",
+		.value = "1",
+	},
+	{
+		.key = "sys.oem_unlock_allowed",
+		.value = "1",
+	},
+	{
+		.key = "sys.rescue_boot_count",
+		.value = "1",
+	},
+	{
+		.key = "sys.retaildemo.enabled",
+		.value = "0",
+	},
+	{
+		.key = "sys.sysctl.extra_free_kbytes",
+		.value = "30375",
+	},
+	{
+		.key = "sys.usb.config",
+		.value = "adb",
+	},
+	{
+		.key = "sys.usb.configfs",
+		.value = "2",
+	},
+	{
+		.key = "sys.usb.controller",
+		.value = "11210000.dwc3",
+	},
+	{
+		.key = "sys.usb.ffs.ready",
+		.value = "1",
+	},
+	{
+		.key = "sys.usb.mtp.device_type",
+		.value = "3",
+	},
+	{
+		.key = "sys.user.0.ce_available",
+		.value = "true",
+	},
+	{
+		.key = "sys.wifitracing.started",
+		.value = "1",
+	},
+	{
+		.key = "vold.has_adoptable",
+		.value = "0",
+	},
+	{
+		.key = "vold.has_quota",
+		.value = "1",
+	},
+	{NULL},
+};
+#endif /* __ANDROID__ */

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -336,6 +336,39 @@ int main(int argc, char** argv) {
 			printf(", %s %s\n", vendor_string, uarch_string);
 		}
 	}
+	printf("Clusters:\n");
+	for (uint32_t i = 0; i < cpuinfo_get_clusters_count(); i++) {
+		const struct cpuinfo_cluster* cluster = cpuinfo_get_cluster(i);
+		if (cluster->processor_count == 1) {
+			printf("\t%" PRIu32 ": 1 processor (%" PRIu32 ")", i, cluster->processor_start);
+		} else {
+			printf("\t%" PRIu32 ": %" PRIu32 " processors (%" PRIu32 "-%" PRIu32 ")",
+			       i,
+			       cluster->processor_count,
+			       cluster->processor_start,
+			       cluster->processor_start + cluster->processor_count - 1);
+		}
+		if (cluster->core_count == 1) {
+			printf(",\t%" PRIu32 ": 1 core (%" PRIu32 ")", i, cluster->core_start);
+		} else {
+			printf(",\t%" PRIu32 ": %" PRIu32 " cores (%" PRIu32 "-%" PRIu32 ")",
+			       i,
+			       cluster->core_count,
+			       cluster->core_start,
+			       cluster->core_start + cluster->core_count - 1);
+		}
+		const char* vendor_string = vendor_to_string(cluster->vendor);
+		const char* uarch_string = uarch_to_string(cluster->uarch);
+		if (vendor_string == NULL) {
+			printf(", vendor 0x%08" PRIx32 " uarch 0x%08" PRIx32 "\n",
+			       (uint32_t)cluster->vendor,
+			       (uint32_t)cluster->uarch);
+		} else if (uarch_string == NULL) {
+			printf(", %s uarch 0x%08" PRIx32 "\n", vendor_string, (uint32_t)cluster->uarch);
+		} else {
+			printf(", %s %s\n", vendor_string, uarch_string);
+		}
+	}
 	printf("Logical processors");
 #if defined(__linux__)
 	printf(" (System ID)");


### PR DESCRIPTION
On newer kernels (6.x+) a separate topology node exists to express the list of cpus associated with each cluster. The cluster topology node explicitly refers to cores that share some resources (e.g. cache) as opposed to 'core_siblings', which only indicate they are on the same physical package.

This distinction is relevant on 6.x, where some devices may have all their cores on a single physical package but cores do not all share the same resources on that package. In these cases, the existing logic incorrectly reports that there is a single cluster (because all cores are siblings), even though not all cores share the same resources.

Test: Verified on ARM64 Android device that has multiple clusters, where core_siblings reports all cores are siblings.
Test: Added mock hardware tests, verified pass on ARM64 hardware.