### PR TITLE
Add CPUINFO_AVOID_SELINUX_VIOLATIONS to ARM parser

### DIFF
--- a/src/arm/android/properties.c
+++ b/src/arm/android/properties.c
@@ -48,13 +48,14 @@ void cpuinfo_arm_android_parse_properties(struct cpuinfo_android_properties prop
 		cpuinfo_android_property_get("ro.board.platform", properties->ro_board_platform);
 	cpuinfo_log_debug("read ro.board.platform = \"%.*s\"", ro_board_platform_length, properties->ro_board_platform);
 
+	const int ro_arch_length = cpuinfo_android_property_get("ro.arch", properties->ro_arch);
+	cpuinfo_log_debug("read ro.arch = \"%.*s\"", ro_arch_length, properties->ro_arch);
+
+#ifndef CPUINFO_AVOID_SELINUX_VIOLATIONS
 	const int ro_mediatek_platform_length =
 		cpuinfo_android_property_get("ro.mediatek.platform", properties->ro_mediatek_platform);
 	cpuinfo_log_debug(
 		"read ro.mediatek.platform = \"%.*s\"", ro_mediatek_platform_length, properties->ro_mediatek_platform);
-
-	const int ro_arch_length = cpuinfo_android_property_get("ro.arch", properties->ro_arch);
-	cpuinfo_log_debug("read ro.arch = \"%.*s\"", ro_arch_length, properties->ro_arch);
 
 	const int ro_chipname_length = cpuinfo_android_property_get("ro.chipname", properties->ro_chipname);
 	cpuinfo_log_debug("read ro.chipname = \"%.*s\"", ro_chipname_length, properties->ro_chipname);
@@ -63,4 +64,9 @@ void cpuinfo_arm_android_parse_properties(struct cpuinfo_android_properties prop
 		cpuinfo_android_property_get("ro.hardware.chipname", properties->ro_hardware_chipname);
 	cpuinfo_log_debug(
 		"read ro.hardware.chipname = \"%.*s\"", ro_hardware_chipname_length, properties->ro_hardware_chipname);
+#else
+	memset(properties->ro_mediatek_platform, 0, sizeof(properties->ro_mediatek_platform));
+	memset(properties->ro_chipname, 0, sizeof(properties->ro_chipname));
+	memset(properties->ro_hardware_chipname, 0, sizeof(properties->ro_hardware_chipname));
+#endif // CPUINFO_AVOID_SELINUX_VIOLATIONS
 }


### PR DESCRIPTION
For Android ARM builds, we previously introduced parsing of some non-standard properties:

* ro.mediatek.platform
* ro.chipname
* ro.hardware.chipname

In this context, 'non-standard' refers to properties that are not supported by all Android devices and in particular, are not specified as part of any domain in Android's platform sepolicy. As a result, processes that contain the cpuinfo library will generate SELinux denials until the system is modified to allow access to these properties, even though they are not valid on these systems.

To avoid breaking existing behavior, introduce a negative-flag that allows users to compile out this behavior.