### PR TITLE
detect Meteor Lake CPU model

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -386,6 +386,9 @@ enum cpuinfo_uarch {
 	/** Intel/Marvell XScale series. */
 	cpuinfo_uarch_xscale = 0x00100600,
 
+	/** Intel Meteor Lake microarchitecture (Core Ultra 1st gen) */
+	cpuinfo_uarch_meteor_lake = 0x00100700,
+
 	/** AMD K5. */
 	cpuinfo_uarch_k5 = 0x00200100,
 	/** AMD K6 and alike. */

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -167,6 +167,8 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x7D: // Ice Lake-Y
 						case 0x7E: // Ice Lake-U
 							return cpuinfo_uarch_sunny_cove;
+						case 0xAA: // Meteor Lake
+							return cpuinfo_uarch_meteor_lake;
 
 						/* Low-power cores */
 						case 0x1C: // Diamondville,


### PR DESCRIPTION
This PR add support for detecting Intel Meteor Lake CPU through its `model number` and `extended model`.