### PR TITLE
Add a API to check SVE Length support on ARM CPU.

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -1670,6 +1670,7 @@ struct cpuinfo_arm_isa {
 	bool sve;
 	bool sve2;
 	bool i8mm;
+	int svelen;
 #endif
 	bool rdm;
 	bool fp16arith;
@@ -2039,6 +2040,30 @@ static inline bool cpuinfo_has_arm_sve2(void) {
 	return cpuinfo_isa.sve2;
 #else
 	return false;
+#endif
+}
+
+static inline bool cpuinfo_support_arm_sve128(void) {
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+    return (cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen >= 16);
+#else
+    return false;
+#endif
+}
+
+static inline bool cpuinfo_support_arm_sve256(void) {
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+    return (cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen >= 32);
+#else
+    return false;
+#endif
+}
+
+static inline bool cpuinfo_support_arm_sve512(void) {
+#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
+    return (cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen >= 64);
+#else
+    return false;
 #endif
 }
 

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -1670,7 +1670,7 @@ struct cpuinfo_arm_isa {
 	bool sve;
 	bool sve2;
 	bool i8mm;
-	unsigned int svelen;
+	uint32_t svelen;
 #endif
 	bool rdm;
 	bool fp16arith;
@@ -2044,14 +2044,11 @@ static inline bool cpuinfo_has_arm_sve2(void) {
 }
 
 // Function to get the max SVE vector length on ARM CPU's which support SVE.
-static inline int cpuinfo_get_max_arm_sve_length(void) {
+static inline uint32_t cpuinfo_get_max_arm_sve_length(void) {
 #if CPUINFO_ARCH_ARM64
-	if ((cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen > 0))
-		return cpuinfo_isa.svelen;
-	else
-		return -1; // Returns -1 on Non SVE supported ARM CPU's.
+	return cpuinfo_isa.svelen * 8; // bytes * 8 = bit length(vector length)
 #else
-	return -1; // Returns -1 on Non ARM CPU's.
+	return 0;
 #endif
 }
 

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -1670,7 +1670,7 @@ struct cpuinfo_arm_isa {
 	bool sve;
 	bool sve2;
 	bool i8mm;
-	int svelen;
+	unsigned int svelen;
 #endif
 	bool rdm;
 	bool fp16arith;
@@ -2043,27 +2043,15 @@ static inline bool cpuinfo_has_arm_sve2(void) {
 #endif
 }
 
-static inline bool cpuinfo_support_arm_sve128(void) {
-#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
-    return (cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen >= 16);
+// Function to get the max SVE vector length on ARM CPU's which support SVE.
+static inline int cpuinfo_get_max_arm_sve_length(void) {
+#if CPUINFO_ARCH_ARM64
+	if ((cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen > 0))
+		return cpuinfo_isa.svelen;
+	else
+		return -1; // Returns -1 on Non SVE supported ARM CPU's.
 #else
-    return false;
-#endif
-}
-
-static inline bool cpuinfo_support_arm_sve256(void) {
-#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
-    return (cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen >= 32);
-#else
-    return false;
-#endif
-}
-
-static inline bool cpuinfo_support_arm_sve512(void) {
-#if CPUINFO_ARCH_ARM || CPUINFO_ARCH_ARM64
-    return (cpuinfo_isa.sve || cpuinfo_isa.sve2) && (cpuinfo_isa.svelen >= 64);
-#else
-    return false;
+	return -1; // Returns -1 on Non ARM CPU's.
 #endif
 }
 

--- a/src/arm/linux/aarch64-isa.c
+++ b/src/arm/linux/aarch64-isa.c
@@ -3,9 +3,6 @@
 #include <arm/linux/api.h>
 #include <cpuinfo/log.h>
 
-#include <sys/prctl.h>
-#include <stdio.h>
-
 void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 	uint32_t features,
 	uint32_t features2,
@@ -141,11 +138,9 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 	}
 	if (features & CPUINFO_ARM_LINUX_FEATURE_SVE) {
 		isa->sve = true;
-		isa->svelen = -1;
 	}
 	if (features2 & CPUINFO_ARM_LINUX_FEATURE2_SVE2) {
 		isa->sve2 = true;
-		isa->svelen = -1;
 	}
 	// SVEBF16 is set iff SVE and BF16 are both supported, but the SVEBF16
 	// feature flag was added in Linux kernel before the BF16 feature flag,
@@ -157,14 +152,24 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 		isa->fhm = true;
 	}
 
-    #define PR_SVE_GET_VL 51
-    #define PR_SVE_VL_LEN_MASK 0xffff
-    int ret = prctl(PR_SVE_GET_VL);
-    if (ret < 0) {
-        perror("prctl(PR_SVE_GET_VL) failed");
-        isa->svelen = 0;  // Assume no SVE support if the call fails
-    } else {
-        // Mask out the SVE vector length bits
-        isa->svelen = ret & PR_SVE_VL_LEN_MASK;
-    }
+#if defined(__linux__)
+#include <sys/prctl.h>
+
+#ifndef PR_SVE_GET_VL
+#define PR_SVE_GET_VL 51
+#endif
+
+#ifndef PR_SVE_VL_LEN_MASK
+#define PR_SVE_VL_LEN_MASK 0xffff
+#endif
+
+	int ret = prctl(PR_SVE_GET_VL);
+	if (ret < 0) {
+		cpuinfo_log_error("prctl(PR_SVE_GET_VL) failed");
+		isa->svelen = 0; // Assume no SVE support if the call fails
+	} else {
+		// Mask out the SVE vector length bits
+		isa->svelen = ret & PR_SVE_VL_LEN_MASK;
+	}
+#endif
 }

--- a/src/arm/linux/aarch64-isa.c
+++ b/src/arm/linux/aarch64-isa.c
@@ -3,6 +3,8 @@
 #include <arm/linux/api.h>
 #include <cpuinfo/log.h>
 
+#include <sys/prctl.h>
+
 void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 	uint32_t features,
 	uint32_t features2,
@@ -152,9 +154,6 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 		isa->fhm = true;
 	}
 
-#if defined(__linux__)
-#include <sys/prctl.h>
-
 #ifndef PR_SVE_GET_VL
 #define PR_SVE_GET_VL 51
 #endif
@@ -171,5 +170,4 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 		// Mask out the SVE vector length bits
 		isa->svelen = ret & PR_SVE_VL_LEN_MASK;
 	}
-#endif
 }

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -172,6 +172,11 @@ int main(int argc, char** argv) {
 	printf("\tARM SVE: %s\n", cpuinfo_has_arm_sve() ? "yes" : "no");
 	printf("\tARM SVE 2: %s\n", cpuinfo_has_arm_sve2() ? "yes" : "no");
 
+	printf("ARM SVE Capabilities:\n");
+	printf("\tSVE 128-bit: %s\n", cpuinfo_support_arm_sve128() ? "Yes" : "No");
+	printf("\tSVE 256-bit: %s\n", cpuinfo_support_arm_sve256() ? "Yes" : "No");
+	printf("\tSVE 512-bit: %s\n", cpuinfo_support_arm_sve512() ? "Yes" : "No");
+
 	printf("Cryptography extensions:\n");
 	printf("\tAES: %s\n", cpuinfo_has_arm_aes() ? "yes" : "no");
 	printf("\tSHA1: %s\n", cpuinfo_has_arm_sha1() ? "yes" : "no");

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -173,9 +173,7 @@ int main(int argc, char** argv) {
 	printf("\tARM SVE 2: %s\n", cpuinfo_has_arm_sve2() ? "yes" : "no");
 
 	printf("ARM SVE Capabilities:\n");
-	printf("\tSVE 128-bit: %s\n", cpuinfo_support_arm_sve128() ? "Yes" : "No");
-	printf("\tSVE 256-bit: %s\n", cpuinfo_support_arm_sve256() ? "Yes" : "No");
-	printf("\tSVE 512-bit: %s\n", cpuinfo_support_arm_sve512() ? "Yes" : "No");
+	printf("\tSVE max length: %d\n", cpuinfo_get_max_arm_sve_length());
 
 	printf("Cryptography extensions:\n");
 	printf("\tAES: %s\n", cpuinfo_has_arm_aes() ? "yes" : "no");


### PR DESCRIPTION
This pull request introduces a new feature to the cpuinfo library that adds an API to return the maximum supported Scalable Vector Extension (SVE) vector length on the given ARM CPU. This enhancement will allow users to query and determine the maximum SVE vector lengths on a given ARM CPU, providing better insights and flexibility for optimizing applications that utilize SVE.

**Key Features:**
**New API Function:**

Introduces a single API function - cpuinfo_get_max_arm_sve_length() that returns the maximum SVE Vector Length supported on the given ARM CPU.

The function is designed to be easy to integrate with existing code in other projects like PyTorch (https://github.com/pytorch/pytorch/pull/119571/) and provides a straightforward interface for querying SVE VL.

**Here's the sample output on SVE supported instance:**

**Query:**
![test_cpp_aug7](https://github.com/user-attachments/assets/0f55fa37-cf54-4fbf-b1bc-a34a27139869)

**Output on SVE256 supported Hardware - Graviton3:**
![test_cpp_output](https://github.com/user-attachments/assets/bef72357-dadd-43e9-8983-33248205782f)
