### PR TITLE
Add android-riscv64 build to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
   cmake-android:
     strategy:
       matrix:
-        script: [android-arm64-build.sh, android-armv7-build.sh, android-x86-build.sh]
+        script: [android-arm64-build.sh, android-armv7-build.sh, android-riscv64-build.sh, android-x86-build.sh]
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -86,7 +86,7 @@ jobs:
         id: setup-ndk
         uses: nttld/setup-ndk@v1.0.6
         with:
-          ndk-version: r23b
+          ndk-version: r27
           add-to-path: false
       - name: Configure and build
         run: scripts/${{ matrix.script }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,7 @@ IF(CPUINFO_SUPPORTED_PLATFORM)
   ELSEIF(CPUINFO_TARGET_PROCESSOR MATCHES "^(riscv(32|64))$")
     LIST(APPEND CPUINFO_SRCS
       src/riscv/uarch.c)
-    IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    IF(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
       LIST(APPEND CPUINFO_SRCS
         src/riscv/linux/init.c
 	src/riscv/linux/riscv-hw.c

--- a/scripts/android-riscv64-build.sh
+++ b/scripts/android-riscv64-build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$ANDROID_NDK" ]
+then
+  echo "ANDROID_NDK not set; please set it to the Android NDK directory"
+  exit 1
+fi
+
+if [ ! -d "$ANDROID_NDK" ]
+then
+  echo "ANDROID_NDK not a directory; did you install it under ${ANDROID_NDK}?"
+  exit 1
+fi
+
+mkdir -p build/android/riscv64
+
+CMAKE_ARGS=()
+
+# CMake-level configuration
+CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake")
+CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Release")
+CMAKE_ARGS+=("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+
+# If Ninja is installed, prefer it to Make
+if [ -x "$(command -v ninja)" ]
+then
+  CMAKE_ARGS+=("-GNinja")
+fi
+
+CMAKE_ARGS+=("-DCPUINFO_LIBRARY_TYPE=static")
+# CMakeLists for Google Benchmark is broken on Android
+CMAKE_ARGS+=("-DCPUINFO_BUILD_BENCHMARKS=OFF")
+CMAKE_ARGS+=("-DCPUINFO_BUILD_TOOLS=ON")
+CMAKE_ARGS+=("-DCPUINFO_BUILD_UNIT_TESTS=ON")
+CMAKE_ARGS+=("-DCPUINFO_BUILD_MOCK_TESTS=ON")
+
+# Android-specific options
+CMAKE_ARGS+=("-DANDROID_NDK=$ANDROID_NDK")
+CMAKE_ARGS+=("-DANDROID_ABI=riscv64")
+CMAKE_ARGS+=("-DANDROID_PLATFORM=android-35")
+CMAKE_ARGS+=("-DANDROID_PIE=ON")
+CMAKE_ARGS+=("-DANDROID_STL=c++_static")
+CMAKE_ARGS+=("-DANDROID_CPP_FEATURES=exceptions")
+
+# Use-specified CMake arguments go last to allow overridding defaults
+CMAKE_ARGS+=($@)
+
+cd build/android/riscv64 && cmake ../../.. \
+    "${CMAKE_ARGS[@]}"
+
+# Cross-platform parallel build
+if [ "$(uname)" == "Darwin" ]
+then
+  cmake --build . -- "-j$(sysctl -n hw.ncpu)"
+else
+  cmake --build . -- "-j$(nproc)"
+fi


### PR DESCRIPTION
The Android NDK supports building for RISC-V as of version r27. Add it to the build workflows here to improve coverage of the RISC-V code.

Fixes: #206