### PR TITLE
Fixes the cpuinfo_get_max_arm_sve_length API bug on NON-SVE supported hardware.

### DIFF
--- a/src/arm/linux/aarch64-isa.c
+++ b/src/arm/linux/aarch64-isa.c
@@ -167,7 +167,7 @@ void cpuinfo_arm64_linux_decode_isa_from_proc_cpuinfo(
 
 	int ret = prctl(PR_SVE_GET_VL);
 	if (ret < 0) {
-		cpuinfo_log_error("prctl(PR_SVE_GET_VL) failed");
+		cpuinfo_log_warning("No SVE support on this machine");
 		isa->svelen = 0; // Assume no SVE support if the call fails
 	} else {
 		// Mask out the SVE vector length bits


### PR DESCRIPTION
The current API - **cpuinfo_get_max_arm_sve_length**() when integrated into PyTorch works well on SVE supported hardware but when tested on Graviton2 (NON SVE hardware), it fails with the below error.

![cpuinfo_error_on_graviton2](https://github.com/user-attachments/assets/2d7abe6a-adc0-4ebe-9f4c-341cdf900b12)

**This PR fixes this bug on Non SVE supported hardware:**

**Changes:**
cpuinfo_log_error (wrong change) -> **cpuinfo_log_warning** (Right change)