### PR TITLE
Android 16KB page size support

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -2,3 +2,4 @@ APP_PLATFORM := android-16
 APP_PIE := true
 APP_STL := c++_static
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_PLATFORM := android-16
+APP_PLATFORM := android-21
 APP_PIE := true
 APP_STL := c++_static
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64


### PR DESCRIPTION
To support new page sizes on Android this additional configuration should be added (https://developer.android.com/guide/practices/page-sizes). 

New NDK r27 has min SDK set to 21 so it also needs to be bumped.