### PR TITLE
Detect AMD Zen 5 microarchitecture

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -419,6 +419,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_zen3 = 0x0020010B,
 	/** AMD Zen 4 microarchitecture. */
 	cpuinfo_uarch_zen4 = 0x0020010C,
+	/** AMD Zen 5 microarchitecture. */
+	cpuinfo_uarch_zen5 = 0x0020010D,
 
 	/** NSC Geode and AMD Geode GX and LX. */
 	cpuinfo_uarch_geode = 0x00200200,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -387,6 +387,8 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 							return cpuinfo_uarch_zen4;
 					}
 					break;
+				case 0x1a:
+					return cpuinfo_uarch_zen5;
 			}
 			break;
 		case cpuinfo_vendor_hygon:

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -132,6 +132,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Zen 3";
 		case cpuinfo_uarch_zen4:
 			return "Zen 4";
+		case cpuinfo_uarch_zen5:
+			return "Zen 5";
 		case cpuinfo_uarch_geode:
 			return "Geode";
 		case cpuinfo_uarch_bobcat:


### PR DESCRIPTION
Detect AMD Family 26 with any model as cpuinfo_uarch_zen5