### PR TITLE
Set the correct L2 size for Ampere Altra (`aarch64`).

### DIFF
--- a/src/arm/cache.c
+++ b/src/arm/cache.c
@@ -1341,7 +1341,8 @@ void cpuinfo_arm_decode_cache(
 			 * information, please refer to the technical manuals
 			 * linked above
 			 */
-			const uint32_t min_l2_size_KB = uarch == cpuinfo_uarch_neoverse_v2 || midr_is_ampere_altra(midr)
+			const uint32_t min_l2_size_KB =
+				uarch == cpuinfo_uarch_neoverse_v2 || midr_is_ampere_altra(midr)
 					? 1024
 					: 256;
 			const uint32_t min_l3_size_KB = 0;

--- a/src/arm/cache.c
+++ b/src/arm/cache.c
@@ -1341,7 +1341,9 @@ void cpuinfo_arm_decode_cache(
 			 * information, please refer to the technical manuals
 			 * linked above
 			 */
-			const uint32_t min_l2_size_KB = uarch == cpuinfo_uarch_neoverse_v2 ? 1024 : 256;
+			const uint32_t min_l2_size_KB = uarch == cpuinfo_uarch_neoverse_v2 || midr_is_ampere_altra(midr)
+					? 1024
+					: 256;
 			const uint32_t min_l3_size_KB = 0;
 
 			*l1i = (struct cpuinfo_cache){

--- a/src/arm/cache.c
+++ b/src/arm/cache.c
@@ -1342,9 +1342,7 @@ void cpuinfo_arm_decode_cache(
 			 * linked above
 			 */
 			const uint32_t min_l2_size_KB =
-				uarch == cpuinfo_uarch_neoverse_v2 || midr_is_ampere_altra(midr)
-					? 1024
-					: 256;
+				(uarch == cpuinfo_uarch_neoverse_v2 || midr_is_ampere_altra(midr)) ? 1024 : 256;
 			const uint32_t min_l3_size_KB = 0;
 
 			*l1i = (struct cpuinfo_cache){

--- a/src/arm/midr.h
+++ b/src/arm/midr.h
@@ -34,6 +34,7 @@
 #define CPUINFO_ARM_MIDR_KRYO_SILVER_820 UINT32_C(0x510F2110)
 #define CPUINFO_ARM_MIDR_EXYNOS_M1_M2 UINT32_C(0x530F0010)
 #define CPUINFO_ARM_MIDR_DENVER2 UINT32_C(0x4E0F0030)
+#define CPUINFO_ARM_MIDR_AMPERE_ALTRA UINT32_C(0x413fd0c1)
 
 inline static uint32_t midr_set_implementer(uint32_t midr, uint32_t implementer) {
 	return (midr & ~CPUINFO_ARM_MIDR_IMPLEMENTER_MASK) |
@@ -165,6 +166,11 @@ inline static bool midr_is_kryo_silver(uint32_t midr) {
 inline static bool midr_is_kryo_gold(uint32_t midr) {
 	const uint32_t uarch_mask = CPUINFO_ARM_MIDR_IMPLEMENTER_MASK | CPUINFO_ARM_MIDR_PART_MASK;
 	return (midr & uarch_mask) == (CPUINFO_ARM_MIDR_KRYO_GOLD & uarch_mask);
+}
+
+inline static bool midr_is_ampere_altra(uint32_t midr) {
+	const uint32_t uarch_mask = CPUINFO_ARM_MIDR_IMPLEMENTER_MASK | CPUINFO_ARM_MIDR_PART_MASK;
+	return (midr & uarch_mask) == (CPUINFO_ARM_MIDR_AMPERE_ALTRA & uarch_mask);
 }
 
 inline static uint32_t midr_score_core(uint32_t midr) {


### PR DESCRIPTION
Use the `midr` to identify Ampere Altra cores and set the L2 cache size to 1MiB (as opposed to the default minimum size of 256KiB for `cpuinfo_uarch_neoverse_n1`).