### PR TITLE
pkg-config: use PROJECT_NAME instead of CMAKE_PROJECT_NAME

### DIFF
--- a/libcpuinfo.pc.in
+++ b/libcpuinfo.pc.in
@@ -3,7 +3,7 @@ exec_prefix=@CMAKE_INSTALL_PREFIX@
 libdir=@libdir_for_pc_file@
 includedir=@includedir_for_pc_file@
 
-Name: lib@CMAKE_PROJECT_NAME@
+Name: lib@PROJECT_NAME@
 Description: Library to detect essential performance optimization information about host CPU.
 Version: 
 URL: @PROJECT_HOMEPAGE_URL@


### PR DESCRIPTION
[`PROJECT_NAME`][1] refers to the most recent `project()` call, while
[`CMAKE_PROJECT_NAME`][2] refers to the top-most `project()` call.

In the cases where cpuinfo is installed as a standalone project, this is
perfectly fine and works as intended where the installed pkg-config file
contains libcpuinfo as the name. However, if cpuinfo is used as a
subproject, such as when using FetchContent, the name of the calling
project would be used instead, leading to something like libOuterProject
rather than libcpuinfo.

[1]: https://cmake.org/cmake/help/latest/variable/PROJECT_NAME.html#variable:PROJECT_NAME
[2]: https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_NAME.html#variable:CMAKE_PROJECT_NAME