### PR TITLE
isa-tool display SME and SME2 for arm

### DIFF
--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -173,6 +173,8 @@ int main(int argc, char** argv) {
 	printf("SIMD extensions:\n");
 	printf("\tARM SVE: %s\n", cpuinfo_has_arm_sve() ? "yes" : "no");
 	printf("\tARM SVE 2: %s\n", cpuinfo_has_arm_sve2() ? "yes" : "no");
+	printf("\tARM SME: %s\n", cpuinfo_has_arm_sme() ? "yes" : "no");
+	printf("\tARM SME 2: %s\n", cpuinfo_has_arm_sme2() ? "yes" : "no");
 
 	printf("ARM SVE Capabilities:\n");
 	printf("\tSVE max length: %d\n", cpuinfo_get_max_arm_sve_length());


### PR DESCRIPTION
When running on an armv9 detect and display SME and SME2 ISAs

Tested on qemu the tool displays the following

SIMD extensions:
	ARM SVE: yes
	ARM SVE 2: yes
	ARM SME: yes
	ARM SME 2: no
