### PR TITLE
Apply `RESTRICT_STATIC` MSVC workaround to `arm/cache.c` as well

### DIFF
--- a/src/arm/cache.c
+++ b/src/arm/cache.c
@@ -10,13 +10,13 @@ void cpuinfo_arm_decode_cache(
 	enum cpuinfo_uarch uarch,
 	uint32_t cluster_cores,
 	uint32_t midr,
-	const struct cpuinfo_arm_chipset chipset[restrict static 1],
+	const struct cpuinfo_arm_chipset chipset[RESTRICT_STATIC 1],
 	uint32_t cluster_id,
 	uint32_t arch_version,
-	struct cpuinfo_cache l1i[restrict static 1],
-	struct cpuinfo_cache l1d[restrict static 1],
-	struct cpuinfo_cache l2[restrict static 1],
-	struct cpuinfo_cache l3[restrict static 1]) {
+	struct cpuinfo_cache l1i[RESTRICT_STATIC 1],
+	struct cpuinfo_cache l1d[RESTRICT_STATIC 1],
+	struct cpuinfo_cache l2[RESTRICT_STATIC 1],
+	struct cpuinfo_cache l3[RESTRICT_STATIC 1]) {
 	switch (uarch) {
 #if CPUINFO_ARCH_ARM && !defined(__ARM_ARCH_7A__) && !defined(__ARM_ARCH_8A__)
 		case cpuinfo_uarch_xscale:


### PR DESCRIPTION
In https://github.com/pytorch/cpuinfo/pull/283 a workaround was introduced to remove the `restrict static` attributes on MSVC where it is not supported.

This was only defined and used in `arm/api.h` however and not in `arm/cache.c`, leading to this file to fail compilation because it is included in `ARM_SRCS` for the `windows_arm64` target in `BUILD.bazel`.

Fix that by replacing `restrict static` with `RESTRICT_STATIC` which will be defined by the `arm/api.h` header that is already included in `arm/cache.c`.
