### PR TITLE
riscv-hw.c: match kernel type in syscall().

### DIFF
--- a/src/riscv/linux/riscv-hw.c
+++ b/src/riscv/linux/riscv-hw.c
@@ -112,7 +112,7 @@ void cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
 	 *
 	 * for more details.
 	 */
-	int ret = syscall(NR_riscv_hwprobe, pairs, pairs_count, cpu_set_size, (unsigned long*)cpu_set, 0 /* flags */);
+	int ret = syscall(NR_riscv_hwprobe, pairs, pairs_count, cpu_set_size, cpu_set, 0 /* flags */);
 #else
 	int ret = __riscv_hwprobe(pairs, pairs_count, cpu_set_size, (unsigned long*)cpu_set, 0 /* flags */);
 #endif


### PR DESCRIPTION
syscall() doesn't care about these types at all, and the kernel uses cpu_set_t, so we're better off just removing the cast entirely.