### PR TITLE
[CI] Fix riscv64-in-qemu build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         build_props:
           - [
               "cmake-linux-riscv64",
-              "riscv64/ubuntu:24.04"
+              "ubuntu:24.04"
           ]
 
     name: ${{ matrix.build_props[0] }}
@@ -113,7 +113,7 @@ jobs:
         uses: docker/setup-docker-action@v4.3.0
       - name: Build cpuinfo in ${{ matrix.build_props[1] }}
         run: |
-          docker run -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "
+          docker run --platform linux/riscv64 -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "
           apt update &&
           apt install -y cmake git gcc g++ &&
           cd /cpuinfo &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3.6.0
+      - name: Setup Docker
+        uses: docker/setup-docker-action@v4.3.0
       - name: Build cpuinfo in ${{ matrix.build_props[1] }}
         run: |
           docker run -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.6.0
       - name: Build cpuinfo in ${{ matrix.build_props[1] }}
         run: |
           docker run -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         build_props:
           - [
               "cmake-linux-riscv64",
-              "ubuntu:24.04"
+              "riscv64/ubuntu:24.04"
           ]
 
     name: ${{ matrix.build_props[0] }}
@@ -109,8 +109,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3.6.0
-      - name: Setup Docker
-        uses: docker/setup-docker-action@v4.3.0
       - name: Build cpuinfo in ${{ matrix.build_props[1] }}
         run: |
           docker run --platform linux/riscv64 -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+        uses: docker/setup-qemu-action@v3.0.0
       - name: Build cpuinfo in ${{ matrix.build_props[1] }}
         run: |
           docker run --platform linux/riscv64 -i -v $(pwd):/cpuinfo ${{ matrix.build_props[1] }} /bin/bash -c "


### PR DESCRIPTION
Tried a few things, but looks like all one needs to do is to add `--platform linux/riscv64` flag to `docker run` command