### PR TITLE
Add Intel Crestmont uarch

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -371,6 +371,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_goldmont = 0x00100404,
 	/** Intel Goldmont Plus microarchitecture (Gemini Lake). */
 	cpuinfo_uarch_goldmont_plus = 0x00100405,
+	/** Intel Crestmont microarchitecture (Sierra Forest). */
+	cpuinfo_uarch_crestmont = 0x00100407,
 
 	/** Intel Knights Ferry HPC boards. */
 	cpuinfo_uarch_knights_ferry = 0x00100500,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -185,6 +185,8 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x5A: // Moorefield
 						case 0x5D: // SoFIA
 							return cpuinfo_uarch_silvermont;
+						case 0xAF: // Sierra Forest
+							return cpuinfo_uarch_crestmont;
 						case 0x4C: // Braswell, Cherry
 							   // Trail
 						case 0x75: // Spreadtrum

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -90,6 +90,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Saltwell";
 		case cpuinfo_uarch_silvermont:
 			return "Silvermont";
+		case cpuinfo_uarch_crestmont:
+			return "Crestmont";
 		case cpuinfo_uarch_airmont:
 			return "Airmont";
 		case cpuinfo_uarch_goldmont:


### PR DESCRIPTION
Darkmont is the uarch used in Sierra Forest
Tested:
make cpu-info
sde -srf -- ./cpu-info