### PR TITLE
Disable neon dot on unknown chipsets on aarch32

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -149,6 +149,8 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc T310");
 		} else if (chipset->series == cpuinfo_arm_chipset_series_unisoc_ums && chipset->model == 312) {
 			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc UMS312");
+		} else if (chipset->vendor == cpuinfo_arm_chipset_vendor_unknown) {
+			cpuinfo_log_warning("VDOT instructions disabled: unknown chipset");
 		} else {
 			switch (midr & (CPUINFO_ARM_MIDR_IMPLEMENTER_MASK | CPUINFO_ARM_MIDR_PART_MASK)) {
 				case UINT32_C(0x4100D0B0): /* Cortex-A76 */


### PR DESCRIPTION
We are seeing intermittent SIGILL crashes when running neon dot kernels on certain UNISOC-based phones. The previous change (https://github.com/pytorch/cpuinfo/pull/265) addressed the majority of these crashes, but we are still seeing some crashes on a small subset of hardware running Meta apps.

I tracked this down to a failure of the chipset detection logic in CPUINFO causing the existing logic to not recognize the soc as one of the UNISOC chips that shouldn't run neon dot instructions. While it would be nice to resolve the chipset detection logic issues, it's only happening on a very small subset of devices and I can't repro it on a local Itel A50 (which is one of the affected prod devices). Maybe due to differing firmware or OS images.

To solve it, I've added an additional piece of logic in arm/linux/aarch32-isa.c to disable neon dot instructions on unknown chipsets. Running this internally at Meta for a few weeks has cleared up the remaining crashes on UNISOC devices (zero instances with this patch). This should solve the issue with minimal collateral damage.