### PR TITLE
Add Intel Gracemont uarch

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -373,6 +373,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_goldmont = 0x00100404,
 	/** Intel Goldmont Plus microarchitecture (Gemini Lake). */
 	cpuinfo_uarch_goldmont_plus = 0x00100405,
+	/** Intel Gracemont microarchitecture (Twin Lake). */
+	cpuinfo_uarch_gracemont = 0x00100406,
 	/** Intel Crestmont microarchitecture (Sierra Forest). */
 	cpuinfo_uarch_crestmont = 0x00100407,
 

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -188,6 +188,8 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x5A: // Moorefield
 						case 0x5D: // SoFIA
 							return cpuinfo_uarch_silvermont;
+						case 0xBE: // Twin Lake
+							return cpuinfo_uarch_gracemont;
 						case 0xAF: // Sierra Forest
 							return cpuinfo_uarch_crestmont;
 						case 0x4C: // Braswell, Cherry

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -92,6 +92,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Saltwell";
 		case cpuinfo_uarch_silvermont:
 			return "Silvermont";
+		case cpuinfo_uarch_gracemont:
+			return "Gracemont";
 		case cpuinfo_uarch_crestmont:
 			return "Crestmont";
 		case cpuinfo_uarch_airmont:


### PR DESCRIPTION
Gracemont is the e-core in Alderlake
Twin Lake is a stand alone Alderlake N cpu, with gracemont uarch. The N150 is an example of Twin Lake.

The family/model are supported by linux
https://github.com/torvalds/linux/blob/master/arch/x86/include/asm/intel-family.h#L180C1-L181C1

Predecessor    Tremont
Successor    Crestmont