### PR TITLE
Add Intel Tremont uarch

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -373,10 +373,14 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_goldmont = 0x00100404,
 	/** Intel Goldmont Plus microarchitecture (Gemini Lake). */
 	cpuinfo_uarch_goldmont_plus = 0x00100405,
-	/** Intel Gracemont microarchitecture (Twin Lake). */
-	cpuinfo_uarch_gracemont = 0x00100406,
+	/** Intel Airmont microarchitecture (10 nm out-of-order Atom). */
+	cpuinfo_uarch_tremont = 0x00100406,
+	/** Intel Gracemont microarchitecture (AlderLake N). */
+	cpuinfo_uarch_gracemont = 0x00100407,
 	/** Intel Crestmont microarchitecture (Sierra Forest). */
-	cpuinfo_uarch_crestmont = 0x00100407,
+	cpuinfo_uarch_crestmont = 0x00100408,
+	/** Intel Darkmont microarchitecture (e-core used in Clearwater Forest). */
+	cpuinfo_uarch_darkmont = 0x00100409,
 
 	/** Intel Knights Ferry HPC boards. */
 	cpuinfo_uarch_knights_ferry = 0x00100500,
@@ -388,8 +392,6 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_knights_hill = 0x00100503,
 	/** Intel Knights Mill Xeon Phi. */
 	cpuinfo_uarch_knights_mill = 0x00100504,
-	/** Intel Darkmont microarchitecture (e-core used in Clearwater Forest). */
-	cpuinfo_uarch_darkmont = 0x00100505,
 
 	/** Intel/Marvell XScale series. */
 	cpuinfo_uarch_xscale = 0x00100600,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -188,10 +188,17 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x5A: // Moorefield
 						case 0x5D: // SoFIA
 							return cpuinfo_uarch_silvermont;
-						case 0xBE: // Twin Lake
+						case 0x86: // Jasper Lake
+						case 0x8A: // Lakefield
+						case 0x96: // Elkhart Lake
+						case 0x9C: // Jacobsville
+							return cpuinfo_uarch_tremont;
+						case 0xBE: // Alder Lake-N
 							return cpuinfo_uarch_gracemont;
 						case 0xAF: // Sierra Forest
 							return cpuinfo_uarch_crestmont;
+						case 0xDD: // Clearwater Forest
+							return cpuinfo_uarch_darkmont;
 						case 0x4C: // Braswell, Cherry
 							   // Trail
 						case 0x75: // Spreadtrum
@@ -208,8 +215,6 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 							return cpuinfo_uarch_knights_landing;
 						case 0x85:
 							return cpuinfo_uarch_knights_mill;
-						case 0xDD: // Clearwater Forest
-							return cpuinfo_uarch_darkmont;
 					}
 					break;
 				case 0x0F:

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -92,16 +92,18 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Saltwell";
 		case cpuinfo_uarch_silvermont:
 			return "Silvermont";
-		case cpuinfo_uarch_gracemont:
-			return "Gracemont";
-		case cpuinfo_uarch_crestmont:
-			return "Crestmont";
 		case cpuinfo_uarch_airmont:
 			return "Airmont";
 		case cpuinfo_uarch_goldmont:
 			return "Goldmont";
 		case cpuinfo_uarch_goldmont_plus:
 			return "Goldmont Plus";
+		case cpuinfo_uarch_tremont:
+			return "Tremont";
+		case cpuinfo_uarch_gracemont:
+			return "Gracemont";
+		case cpuinfo_uarch_crestmont:
+			return "Crestmont";
 		case cpuinfo_uarch_darkmont:
 			return "Darkmont";
 		case cpuinfo_uarch_knights_ferry:


### PR DESCRIPTION
Tremont is the e-core (10nm Atom) in Jasperlake,Elkhart Lake, Jacobville and Lakefield

The family/model are supported by linux
https://github.com/torvalds/linux/blob/master/arch/x86/include/asm/intel-family.h#L176-L178 Documented on wikichip
https://en.wikichip.org/wiki/intel/cpuid#Small_Cores Supported by Intel sde -tnt

Reordered e-core uarch by generation
darkmont is an e-core used in both hybrid laptops and server, so move to ecore gracemont model 0xBE is confirmed for Alderlake N, so redocument support

Predecessor Goldmont Plus
Successor Gracemont