### PR TITLE
Fix Unisoc T618 Chipset Detection

### DIFF
--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -953,7 +953,7 @@ static bool match_sc(const char* start, const char* end, struct cpuinfo_arm_chip
 }
 
 /**
- * Tries to match, case-sentitively, /Unisoc T\d{3,4}/ signature for Unisoc T
+ * Tries to match, case-sentitively, /Unisoc T\d{3,4}/ or /UNISOC T\d{3,4}/ signature for Unisoc T
  * chipset. If match successful, extracts model information into \p chipset
  * argument.
  *
@@ -967,7 +967,7 @@ static bool match_sc(const char* start, const char* end, struct cpuinfo_arm_chip
  * @returns true if signature matched, false otherwise.
  */
 static bool match_t(const char* start, const char* end, struct cpuinfo_arm_chipset chipset[restrict static 1]) {
-	/* Expect 11-12 symbols: "Unisoc T" (8 symbols) + 3-4-digit model number
+	/* Expect 11-12 symbols: "Unisoc T" / "UNISOC T" (8 symbols) + 3-4-digit model number
 	 */
 	const size_t length = end - start;
 	switch (length) {
@@ -978,16 +978,18 @@ static bool match_t(const char* start, const char* end, struct cpuinfo_arm_chips
 			return false;
 	}
 
-	/* Check that string starts with "Unisoc T". The first four characters
+	/* Check that string starts with "Unisoc T" or "UNISOC T". The first four characters
 	 * are loaded as 32-bit little endian word */
 	const uint32_t expected_unis = load_u32le(start);
-	if (expected_unis != UINT32_C(0x73696E55) /* "sinU" = reverse("Unis") */) {
+	if (expected_unis != UINT32_C(0x73696E55) /* "sinU" = reverse("Unis") */ &&
+	    expected_unis != UINT32_C(0x53494E55) /* "SINU" = reverse("UNIS") */) {
 		return false;
 	}
 
 	/* The next four characters are loaded as 32-bit little endian word */
 	const uint32_t expected_oc_t = load_u32le(start + 4);
-	if (expected_oc_t != UINT32_C(0x5420636F) /* "T co" = reverse("oc T") */) {
+	if (expected_oc_t != UINT32_C(0x5420636F) /* "T co" = reverse("oc T") */ &&
+	    expected_oc_t != UINT32_C(0x5420434F) /* "T CO" = reverse("OC T") */) {
 		return false;
 	}
 

--- a/test/name/proc-cpuinfo-hardware.cc
+++ b/test/name/proc-cpuinfo-hardware.cc
@@ -460,6 +460,7 @@ TEST(PROC_CPUINFO_HARDWARE, telechips) {
 
 TEST(PROC_CPUINFO_HARDWARE, unisoc) {
 	EXPECT_EQ("Unisoc T301", parse_proc_cpuinfo_hardware("Unisoc T301", 4, 1800000));
+	EXPECT_EQ("Unisoc T618", parse_proc_cpuinfo_hardware("UNISOC T618", 4, 1800000));
 	EXPECT_EQ("Unisoc UMS312", parse_proc_cpuinfo_hardware("Unisoc UMS312", 4, 1800000));
 }
 


### PR DESCRIPTION
Add support for uppercase "UNISOC T" prefix in `match_t` function to handle devices like Samsung Galaxy Tab A8 (SM-X205N) that report "UNISOC T618" instead of the expected mixed-case "Unisoc T618".

The function now explicitly matches both variants:
- "Unisoc T" (mixed case, existing)
- "UNISOC T" (uppercase, new)

This ensures proper chipset vendor detection on affected Samsung devices where the uppercase variant caused match failures.

Includes test case for "UNISOC T618" detection.
Fixes #306 