### PR TITLE
Allow for longer CPU names

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -732,7 +732,7 @@ struct cpuinfo_cluster {
 	uint64_t frequency;
 };
 
-#define CPUINFO_PACKAGE_NAME_MAX 48
+#define CPUINFO_PACKAGE_NAME_MAX 64
 
 struct cpuinfo_package {
 	/** SoC or processor chip model name */


### PR DESCRIPTION
Increase CPUINFO_PACKAGE_NAME_MAX to allow for longer strings, such as "Snapdragon® X Elite - X1E78100 - Qualcomm® Oryon™ CPU", which is 53 characters and WideCharToMultiByte converts to a 57 byte string.