### PR TITLE
Disable neon dot on all UNISOC-based phones.

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -142,15 +142,10 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 		 * - Neoverse V1 cores
 		 * - Neoverse V2 cores
 		 */
-		if (chipset->series == cpuinfo_arm_chipset_series_spreadtrum_sc && chipset->model == 9863) {
-			cpuinfo_log_warning(
-				"VDOT instructions disabled: cause occasional SIGILL on Spreadtrum SC9863A");
-		} else if (chipset->series == cpuinfo_arm_chipset_series_unisoc_t && chipset->model == 310) {
-			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc T310");
-		} else if (chipset->series == cpuinfo_arm_chipset_series_unisoc_ums && chipset->model == 312) {
-			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc UMS312");
-		} else if (chipset->vendor == cpuinfo_arm_chipset_vendor_unknown) {
-			cpuinfo_log_warning("VDOT instructions disabled: unknown chipset");
+		if (chipset->series == cpuinfo_arm_chipset_series_spreadtrum_sc ||
+			chipset->series == cpuinfo_arm_chipset_series_unisoc_t ||
+			chipset->series == cpuinfo_arm_chipset_series_unisoc_ums) {
+			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc");
 		} else {
 			switch (midr & (CPUINFO_ARM_MIDR_IMPLEMENTER_MASK | CPUINFO_ARM_MIDR_PART_MASK)) {
 				case UINT32_C(0x4100D0B0): /* Cortex-A76 */


### PR DESCRIPTION
Instead of disabling neon dot on all unknown vendors, limit the disabling to known unisoc vendor.
Fixes a performance regression seen on Samsung and Pixel devices that have 'unknown' vendor.

On Samsung S23  Qualcomm medium core (A715)
SoC name: Unknown
Microarchitectures:
	1x Cortex-X3
	4x Cortex-A715
	3x Cortex-A510

XNNPACK/bench/subgraph/benchmark --benchmark_filter=MobileNetV2
Was
QS8MobileNetV2/process_time/real_time       32116 us        31926 us           22 cpufreq=2.8032G
Now
QS8MobileNetV2/process_time/real_time       10531 us        10467 us           66 cpufreq=2.8032G

Fixes #322

