### PR TITLE
use bazel platforms to correctly detect platforms and CPU types

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -230,241 +230,268 @@ cc_library(
 config_setting(
     name = "linux_x86_64",
     values = {"cpu": "k8"},
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
 )
 
 config_setting(
     name = "linux_arm",
-    values = {"cpu": "arm"},
+    constraint_values = [
+        "@platforms//cpu:arm",
+        "@platforms//os:linux",
+    ],
 )
 
-config_setting(
+alias(
     name = "linux_armhf",
-    values = {"cpu": "armhf"},
+    actual = ":linux_arm",
 )
 
 config_setting(
     name = "linux_armv7a",
-    values = {"cpu": "armv7a"},
+    constraint_values = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:linux",
+    ],
 )
 
-config_setting(
+alias(
     name = "linux_armeabi",
-    values = {"cpu": "armeabi"},
+    actual = ":linux_arm",
 )
 
 config_setting(
     name = "linux_aarch64",
-    values = {"cpu": "aarch64"},
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
 )
 
 config_setting(
     name = "linux_mips64",
-    values = {"cpu": "mips64"},
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:mips64",
+    ],
 )
 
 config_setting(
     name = "linux_riscv32",
-    values = {"cpu": "riscv32"},
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:riscv32",
+    ],
 )
 
 config_setting(
     name = "linux_riscv64",
-    values = {"cpu": "riscv64"},
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:riscv64",
+    ],
 )
 
 config_setting(
     name = "linux_s390x",
-    values = {"cpu": "s390x"},
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
 )
 
-config_setting(
+alias(
     name = "macos_x86_64_legacy",
-    values = {
-        "apple_platform_type": "macos",
-        "cpu": "darwin",
-    },
+    actual = ":macos_x86_64",
 )
 
 config_setting(
     name = "macos_x86_64",
-    values = {
-        "apple_platform_type": "macos",
-        "cpu": "darwin_x86_64",
-    },
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 config_setting(
     name = "windows_x86_64",
-    values = {"cpu": "x64_windows"},
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 config_setting(
     name = "windows_arm64",
-    values = {"cpu": "arm64_windows"},
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:arm64",
+    ],
 )
 
 config_setting(
     name = "android_armv7",
-    values = {
-        "crosstool_top": "//external:android/crosstool",
-        "cpu": "armeabi-v7a",
-    },
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:armv7",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "android_arm64",
-    values = {
-        "crosstool_top": "//external:android/crosstool",
-        "cpu": "arm64-v8a",
-    },
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:arm64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "android_riscv64",
-    values = {
-        "crosstool_top": "//external:android/crosstool",
-        "cpu": "riscv64",
-    },
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:riscv64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "android_x86",
-    values = {
-        "crosstool_top": "//external:android/crosstool",
-        "cpu": "x86",
-    },
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:i386",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "android_x86_64",
-    values = {
-        "crosstool_top": "//external:android/crosstool",
-        "cpu": "x86_64",
-    },
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_64",
+    ],
     visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "ios_armv7",
-    values = {
-        "apple_platform_type": "ios",
-        "cpu": "ios_armv7",
-    },
+    constraint_values = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:ios",
+    ],
 )
 
 config_setting(
     name = "ios_arm64",
-    values = {
-        "apple_platform_type": "ios",
-        "cpu": "ios_arm64",
-    },
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:ios",
+    ],
 )
 
 config_setting(
     name = "ios_arm64e",
-    values = {
-        "apple_platform_type": "ios",
-        "cpu": "ios_arm64e",
-    },
+    constraint_values = [
+        "@platforms//cpu:arm64e",
+        "@platforms//os:ios",
+    ],
 )
 
 config_setting(
     name = "macos_arm64",
-    values = {
-        "apple_platform_type": "macos",
-        "cpu": "darwin_arm64",
-    },
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:macos",
+    ],
 )
 
 config_setting(
     name = "ios_x86",
-    values = {
-        "apple_platform_type": "ios",
-        "cpu": "ios_i386",
-    },
+    constraint_values = [
+        "@platforms//cpu:i386",
+        "@platforms//os:ios",
+    ],
 )
 
 config_setting(
     name = "ios_x86_64",
-    values = {
-        "apple_platform_type": "ios",
-        "cpu": "ios_x86_64",
-    },
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:ios",
+    ],
 )
 
-config_setting(
+alias(
     name = "ios_sim_arm64",
-    values = {
-        "apple_platform_type": "ios",
-        "cpu": "ios_sim_arm64",
-    },
+    actual = ":ios_arm64",
 )
 
 config_setting(
     name = "watchos_armv7k",
-    values = {
-        "apple_platform_type": "watchos",
-        "cpu": "watchos_armv7k",
-    },
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:armv7k",
+    ],
 )
 
 config_setting(
     name = "watchos_arm64_32",
-    values = {
-        "apple_platform_type": "watchos",
-        "cpu": "watchos_arm64_32",
-    },
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:arm64_32",
+    ],
 )
 
 config_setting(
     name = "watchos_x86",
-    values = {
-        "apple_platform_type": "watchos",
-        "cpu": "watchos_i386",
-    },
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:i386",
+    ],
 )
 
 config_setting(
     name = "watchos_x86_64",
-    values = {
-        "apple_platform_type": "watchos",
-        "cpu": "watchos_x86_64",
-    },
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 config_setting(
     name = "tvos_arm64",
-    values = {
-        "apple_platform_type": "tvos",
-        "cpu": "tvos_arm64",
-    },
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:tvos",
+    ],
 )
 
 config_setting(
     name = "tvos_x86_64",
-    values = {
-        "apple_platform_type": "tvos",
-        "cpu": "tvos_x86_64",
-    },
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:tvos",
+    ],
 )
 
 config_setting(
     name = "emscripten_wasm",
-    values = {
-        "cpu": "wasm",
-    },
+    constraint_values = [
+        "@platforms//os:emscripten",
+        "@platforms//cpu:wasm32",
+    ],
 )
 
 config_setting(
     name = "emscripten_wasmsimd",
-    values = {
-        "cpu": "wasm",
-        "features": "wasm_simd",
-    },
+    constraint_values = [
+        "@platforms//os:emscripten",
+        "@platforms//cpu:wasm32",
+    ],
+    features = ["simd"],
 )
 
 config_setting(
@@ -476,7 +503,8 @@ config_setting(
 
 config_setting(
     name = "freebsd_x86_64",
-    values = {
-        "cpu": "freebsd",
-    },
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:freebsd",
+    ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,1 +1,3 @@
 module(name = "cpuinfo")
+
+bazel_dep(name = "platforms", version = "1.0.0")


### PR DESCRIPTION
- the old crosstool_top method no longer works with bazel 8+