### PR TITLE
Fix Windows ARM64 build warnings (treated as error)

### DIFF
--- a/src/arm/windows/init-by-logical-sys-info.c
+++ b/src/arm/windows/init-by-logical-sys-info.c
@@ -750,12 +750,6 @@ void store_core_info_per_processor(
 	if (cores) {
 		processors[processor_global_index].core = cores + core_id;
 		cores[core_id].core_id = core_id;
-
-		if (chip_info->uarchs == NULL) {
-			cpuinfo_log_error("uarch is NULL for core %d", core_id);
-			return;
-		}
-
 		cores[core_id].uarch = chip_info->uarchs[0].uarch;
 		cores[core_id].frequency = chip_info->uarchs[0].frequency;
 
@@ -842,7 +836,6 @@ static bool connect_packages_cores_clusters_by_processors(
 		processor->cluster = cluster;
 
 		if (chip_info) {
-			size_t converted_chars = 0;
 			if (!WideCharToMultiByte(
 				    CP_UTF8,
 				    WC_ERR_INVALID_CHARS,

--- a/src/arm/windows/init.c
+++ b/src/arm/windows/init.c
@@ -21,7 +21,6 @@ static struct woa_chip_info woa_chip_unknown = {L"Unknown", {{cpuinfo_vendor_unk
 
 BOOL CALLBACK cpuinfo_arm_windows_init(PINIT_ONCE init_once, PVOID parameter, PVOID* context) {
 	struct woa_chip_info* chip_info = NULL;
-	enum cpuinfo_vendor vendor = cpuinfo_vendor_unknown;
 
 	set_cpuinfo_isa_fields();
 


### PR DESCRIPTION
- init.c:24:22: error: unused variable 'vendor'
- init-by-logical-sys-info.c:845:11: error: unused variable 'converted_chars'
- init-by-logical-sys-info.c:754:18: error: comparison of array 'chip_info->uarchs' equal to a null pointer