### PR TITLE
Update googletest and googlebench dependencies

### DIFF
--- a/bench/get-current.cc
+++ b/bench/get-current.cc
@@ -2,40 +2,40 @@
 
 #include <cpuinfo.h>
 
-static void cpuinfo_get_current_processor(benchmark::State& state) {
+static void cpuinfo_get_current_processor_bench(benchmark::State& state) {
 	cpuinfo_initialize();
 	while (state.KeepRunning()) {
 		const cpuinfo_processor* current_processor = cpuinfo_get_current_processor();
 		benchmark::DoNotOptimize(current_processor);
 	}
 }
-BENCHMARK(cpuinfo_get_current_processor)->Unit(benchmark::kNanosecond);
+BENCHMARK(cpuinfo_get_current_processor_bench)->Unit(benchmark::kNanosecond);
 
-static void cpuinfo_get_current_core(benchmark::State& state) {
+static void cpuinfo_get_current_core_bench(benchmark::State& state) {
 	cpuinfo_initialize();
 	while (state.KeepRunning()) {
 		const cpuinfo_core* current_core = cpuinfo_get_current_core();
 		benchmark::DoNotOptimize(current_core);
 	}
 }
-BENCHMARK(cpuinfo_get_current_core)->Unit(benchmark::kNanosecond);
+BENCHMARK(cpuinfo_get_current_core_bench)->Unit(benchmark::kNanosecond);
 
-static void cpuinfo_get_current_uarch_index(benchmark::State& state) {
+static void cpuinfo_get_current_uarch_index_bench(benchmark::State& state) {
 	cpuinfo_initialize();
 	while (state.KeepRunning()) {
 		const uint32_t uarch_index = cpuinfo_get_current_uarch_index();
 		benchmark::DoNotOptimize(uarch_index);
 	}
 }
-BENCHMARK(cpuinfo_get_current_uarch_index)->Unit(benchmark::kNanosecond);
+BENCHMARK(cpuinfo_get_current_uarch_index_bench)->Unit(benchmark::kNanosecond);
 
-static void cpuinfo_get_current_uarch_index_with_default(benchmark::State& state) {
+static void cpuinfo_get_current_uarch_index_with_default_bench(benchmark::State& state) {
 	cpuinfo_initialize();
 	while (state.KeepRunning()) {
 		const uint32_t uarch_index = cpuinfo_get_current_uarch_index_with_default(0);
 		benchmark::DoNotOptimize(uarch_index);
 	}
 }
-BENCHMARK(cpuinfo_get_current_uarch_index_with_default)->Unit(benchmark::kNanosecond);
+BENCHMARK(cpuinfo_get_current_uarch_index_with_default_bench)->Unit(benchmark::kNanosecond);
 
 BENCHMARK_MAIN();

--- a/bench/init.cc
+++ b/bench/init.cc
@@ -2,11 +2,11 @@
 
 #include <cpuinfo.h>
 
-static void cpuinfo_initialize(benchmark::State& state) {
+static void cpuinfo_initialize_bench(benchmark::State& state) {
 	while (state.KeepRunning()) {
 		cpuinfo_initialize();
 	}
 }
-BENCHMARK(cpuinfo_initialize)->Iterations(1)->Unit(benchmark::kMillisecond);
+BENCHMARK(cpuinfo_initialize_bench)->Iterations(1)->Unit(benchmark::kMillisecond);
 
 BENCHMARK_MAIN();

--- a/cmake/DownloadGoogleBenchmark.cmake
+++ b/cmake/DownloadGoogleBenchmark.cmake
@@ -1,11 +1,11 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.18 FATAL_ERROR)
 
 PROJECT(googlebenchmark-download NONE)
 
 INCLUDE(ExternalProject)
 ExternalProject_Add(googlebenchmark
-	URL https://github.com/google/benchmark/archive/v1.6.1.zip
-	URL_HASH SHA256=367e963b8620080aff8c831e24751852cffd1f74ea40f25d9cc1b667a9dd5e45
+	URL https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz
+	URL_HASH SHA256=b334658edd35efcf06a99d9be21e4e93e092bd5f95074c1673d5c8705d95c104
 	SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googlebenchmark"
 	BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googlebenchmark"
 	CONFIGURE_COMMAND ""

--- a/cmake/DownloadGoogleTest.cmake
+++ b/cmake/DownloadGoogleTest.cmake
@@ -1,11 +1,11 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.18 FATAL_ERROR)
 
 PROJECT(googletest-download NONE)
 
 INCLUDE(ExternalProject)
 ExternalProject_Add(googletest
-	URL https://github.com/google/googletest/archive/release-1.11.0.zip
-	URL_HASH SHA256=353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a
+	URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.zip
+	URL_HASH SHA256=40d4ec942217dcc84a9ebe2a68584ada7d4a33a8ee958755763278ea1c5e18ff
 	SOURCE_DIR "${CONFU_DEPENDENCIES_SOURCE_DIR}/googletest"
 	BINARY_DIR "${CONFU_DEPENDENCIES_BINARY_DIR}/googletest"
 	CONFIGURE_COMMAND ""


### PR DESCRIPTION
Fix issues with CMake 4 dropping compatibility for old versions. This is causing CI failures (see https://github.com/pytorch/cpuinfo/actions/runs/19111787654/job/54633008879).

* Update googletest to 1.17 (from 1.11) and googlebenchmark to 1.9.4 (from 1.6.1).
  * CMake 4.x complains about the CMake 3.5 minimum version used in dependencies.
* Bump the minimum CMake version in DownloadGoogleTest/Benchmark CMake files (it complains).

I also ran into a naming conflict in the benchmarks with the benchmark functions shadowing the cpuinfo functions they call. I'm not entirely sure why this is a problem after the dependency update, but I've added a _bench suffix, which resolves the issue.