### PR TITLE
Fix missing AMD cache info when running on a VM

### DIFF
--- a/src/x86/api.h
+++ b/src/x86/api.h
@@ -105,6 +105,7 @@ CPUINFO_INTERNAL void cpuinfo_x86_detect_topology(
 CPUINFO_INTERNAL void cpuinfo_x86_detect_cache(
 	uint32_t max_base_index,
 	uint32_t max_extended_index,
+	/* amd_topology_extensions is not used, kept for backward compatibility */
 	bool amd_topology_extensions,
 	enum cpuinfo_vendor vendor,
 	const struct cpuinfo_x86_model_info* model_info,

--- a/src/x86/cache/init.c
+++ b/src/x86/cache/init.c
@@ -87,7 +87,7 @@ void cpuinfo_x86_detect_cache(
 			}
 		}
 	}
-	if (amd_topology_extensions && max_extended_index >= UINT32_C(0x8000001D)) {
+	if (max_extended_index >= UINT32_C(0x8000001D)) {
 		struct cpuid_regs leaf0x8000001D;
 		uint32_t input_ecx = 0;
 		do {


### PR DESCRIPTION
Summary: Fix https://github.com/pytorch/pytorch/issues/138718. This PR is verified to fix the issue and will be guarded on the PyTorch CI.

When running on a VM, the AMD TopologyExtensions bit can be cleared, but that shouldn't stop us from reading the cache information.