### PR TITLE
Re-enable Neon dot on unknown chipsets (Armv7), improve Unisoc vendor detection

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -149,8 +149,6 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc T310");
 		} else if (chipset->series == cpuinfo_arm_chipset_series_unisoc_ums && chipset->model == 312) {
 			cpuinfo_log_warning("VDOT instructions disabled: cause occasional SIGILL on Unisoc UMS312");
-		} else if (chipset->vendor == cpuinfo_arm_chipset_vendor_unknown) {
-			cpuinfo_log_warning("VDOT instructions disabled: unknown chipset");
 		} else {
 			switch (midr & (CPUINFO_ARM_MIDR_IMPLEMENTER_MASK | CPUINFO_ARM_MIDR_PART_MASK)) {
 				case UINT32_C(0x4100D0B0): /* Cortex-A76 */

--- a/src/arm/linux/chipset.c
+++ b/src/arm/linux/chipset.c
@@ -4008,6 +4008,20 @@ static inline struct cpuinfo_arm_chipset disambiguate_spreadtrum_chipset(
 	return *ro_board_platform_chipset;
 }
 
+static enum cpuinfo_arm_chipset_vendor disambiguate_chipset_vendor(
+	enum cpuinfo_arm_chipset_vendor vendor_a,
+	enum cpuinfo_arm_chipset_vendor vendor_b) {
+	/* Some UNISOC-based platforms reporting conflicting vendor names depending
+	 * on the source. For phones that report both UNISOC and Spreadtrum, treat it
+	 * as UNISOC. */
+	if (vendor_a == cpuinfo_arm_chipset_vendor_unisoc && vendor_b == cpuinfo_arm_chipset_vendor_spreadtrum ||
+	    vendor_a == cpuinfo_arm_chipset_vendor_spreadtrum && vendor_b == cpuinfo_arm_chipset_vendor_unisoc) {
+		return cpuinfo_arm_chipset_vendor_unisoc;
+	}
+
+	return cpuinfo_arm_chipset_vendor_unknown;
+}
+
 /*
  * Decodes chipset name from Android system properties:
  * - /proc/cpuinfo Hardware string
@@ -4068,10 +4082,19 @@ struct cpuinfo_arm_chipset cpuinfo_arm_android_decode_chipset(
 			} else if (vendor != decoded_vendor) {
 				/* Parsing different system properties produces
 				 * different chipset vendors. This situation is
-				 * rare. */
-				cpuinfo_log_error(
-					"chipset detection failed: different chipset vendors reported in different system properties");
-				goto finish;
+				 * rare. Try to disambiguate for known cases,
+				 * otherwise treat as unknown. */
+
+				enum cpuinfo_arm_chipset_vendor disambiguated_vendor =
+					disambiguate_chipset_vendor(vendor, decoded_vendor);
+
+				if (disambiguated_vendor != cpuinfo_arm_chipset_vendor_unknown) {
+					vendor = disambiguated_vendor;
+				} else {
+					cpuinfo_log_error(
+						"chipset detection failed: different chipset vendors reported in different system properties");
+					goto finish;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In https://github.com/pytorch/cpuinfo/pull/265, I disabled Neon dot product instructions on certain Unisoc chipsets due to sporadic SIGILL crashes. This reduced the occurance substantially, but we still saw some crashes on Unisoc phones. I tracked this down to cpuinfo vendor detection failing on some phones due to conflicting Unisoc and Spreadtrum vendor info and thus not hitting the check. I disabled neondot on all unknown chipsets on armv7 in https://github.com/pytorch/cpuinfo/pull/300, based on the (faulty) assumption that major chipsets would not be considered to have an unknown vendor.

That assumption was not correct, so I've refined the check in this PR to resolve the ambiguity in vendor detection and re-enabling neon dot instructions on unknown chipsets in armv7 mode. This should resolve the issue for unisoc phones and undo any perf regression for non-Unisoc devices.