### PR TITLE
Fix overread asan error of brand_string

### DIFF
--- a/src/x86/init.c
+++ b/src/x86/init.c
@@ -72,7 +72,7 @@ void cpuinfo_x86_init_processor(struct cpuinfo_x86_processor* processor) {
 		for (uint32_t i = 0; i < 3; i++) {
 			brand_string[i] = cpuid(UINT32_C(0x80000002) + i);
 		}
-		memcpy(processor->brand_string, brand_string, sizeof(processor->brand_string));
+		memcpy(processor->brand_string, brand_string, sizeof(brand_string));
 		cpuinfo_log_debug("raw CPUID brand string: \"%48s\"", processor->brand_string);
 	}
 }


### PR DESCRIPTION
- Brand string is 3 rows of cpuid which is 48 bytes.
- Allow for CPUINFO_PACKAGE_NAME_MAX to be 64 bytes for benefit of Oryon

Fixes #343