### PR TITLE
Add fallback for ARM Windows fp16 detection.

### DIFF
--- a/src/arm/windows/init.c
+++ b/src/arm/windows/init.c
@@ -249,6 +249,14 @@ static void set_cpuinfo_isa_fields(void) {
 	// guarantee that, but it holds in practice.
 	cpuinfo_isa.rdm = dotprod;
 
+	// PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE may not be available in older
+	// Windows versions. If fp16arith was not detected with
+	// IsProcessorFeaturePresent(PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE), fall
+	// back to using the value of dotprod.
+	if (!cpuinfo_isa.fp16arith) {
+		cpuinfo_isa.fp16arith = dotprod;
+	}
+
 	/* Windows API reports all or nothing for cryptographic instructions. */
 	const bool crypto = IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0;
 	cpuinfo_isa.aes = crypto;


### PR DESCRIPTION
Background: On a Windows ARM system, I observed that `cpuinfo_has_arm_fp16_arith()` started to return false after upgrading to a more recent cpuinfo version.

In #333, the initialization of `cpuinfo_isa.fp16arith` was updated to use `IsProcessorFeaturePresent(PF_ARM_V82_FP16_INSTRUCTIONS_AVAILABLE)`. I suspect that this is not supported on older Windows versions.

This change adds a fallback path to set `cpuinfo_isa.fp16arith` the old way.
https://github.com/pytorch/cpuinfo/blob/d3a86a813e2bb49d1eb5841ec12e2b135867ab98/src/arm/windows/init.c#L205-L208