### PR TITLE
cpuid-dump should iterate through all CPUs

### DIFF
--- a/tools/cpuid-dump.c
+++ b/tools/cpuid-dump.c
@@ -105,28 +105,10 @@ int main(int argc, char** argv) {
 		exit(1);
 	}
 	n_log_proc = CPU_COUNT(&mask_default);
-#endif
-	if (max_base_index >= 1) {
-		// TODO: handle case of >256 logical CPUs, or multiple packages
-		const struct cpuid_regs regs = cpuid(1);
-		uint32_t n_apic_id;
-		if (regs.edx & UINT32_C(0x10000000)) { // Number of logical CPUs field is valid
-			n_apic_id = ((regs.ebx & UINT32_C(0x00ff0000)) >> 16);
-
-#ifdef __linux__
-			if (n_apic_id != n_log_proc)
-				fprintf(stderr,
-					"WARNING: %d logical CPUs per CPUID.01h.EBX[23:16] != %d per sched_getaffinity()\n",
-					n_apic_id,
-					n_log_proc);
 #else
-			if (n_apic_id > 1)
-				fprintf(stderr,
-					"WARNING: %d logical CPUs per CPUID.01h.EBX, results may vary by logical CPU\n",
-					n_apic_id);
+	fprintf(stderr,
+		"WARNING: results may vary by CPU, core or thread, but switching CPU is unsupported.\n");
 #endif
-		}
-	}
 
 	for (uint32_t lp = 0; lp < n_log_proc; lp++) {
 		force_one_cpu(lp, n_log_proc);


### PR DESCRIPTION
(This PR also includes https://github.com/pytorch/cpuinfo/pull/349, but I can factor that out if preferred.)

As Intel puts it: "CPUID, by design, returns different values depending on the core it is executed on" (see https://www.intel.com/content/www/us/en/developer/articles/guide/12th-gen-intel-core-processor-gamedev-guide.html#inpage-nav-1-5-2:~:text=CPUID%2C%20by%20design%2C%20returns%20different%20values%20depending%20on%20the%20core%20it%20is%20executed%20on)

In particular, leaves 1, 4, 0x0b, 0x1a, and 0x1f are known to vary by core. Leaf 0x1a differentiates core types on hybrid CPUs

In order to aid in exploration of CPUID contents, `cpuid-dump` should dump CPUID results from *all* CPUs, rather than just one.  This is currently implemented for Linux only, using the `sched_setaffinity(2)` system call.