### PR TITLE
Add Oryon V3 uarch detect

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -538,6 +538,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_saphira = 0x00400104,
 	/** Qualcomm Oryon. */
 	cpuinfo_uarch_oryon = 0x00400105,
+	/** Qualcomm Oryon V3. */
+	cpuinfo_uarch_oryon_v3 = 0x00400106,
 
 	/** Nvidia Denver. */
 	cpuinfo_uarch_denver = 0x00500100,

--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -348,6 +348,9 @@ void cpuinfo_arm_decode_vendor_uarch(
 				case 0x001:
 					*uarch = cpuinfo_uarch_oryon;
 					break;
+				case 0x002:
+					*uarch = cpuinfo_uarch_oryon_v3;
+					break;
 				case 0xC00:
 					*uarch = cpuinfo_uarch_falkor;
 					break;

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -242,6 +242,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Saphira";
 		case cpuinfo_uarch_oryon:
 			return "Oryon";
+		case cpuinfo_uarch_oryon_v3:
+			return "Oryon V3";
 		case cpuinfo_uarch_denver:
 			return "Denver";
 		case cpuinfo_uarch_denver2:


### PR DESCRIPTION
Tested with One Plus 15
```
cpu-info util: 
Microarchitectures:
	8x Oryon V3
Cores:
	0: 1 processor (0), Qualcomm Oryon V3
	1: 1 processor (1), Qualcomm Oryon V3
	2: 1 processor (2), Qualcomm Oryon V3
	3: 1 processor (3), Qualcomm Oryon V3
	4: 1 processor (4), Qualcomm Oryon V3
	5: 1 processor (5), Qualcomm Oryon V3
	6: 1 processor (6), Qualcomm Oryon V3
	7: 1 processor (7), Qualcomm Oryon V3
Clusters:
	0: 2 processors (0-1),	0: 2 cores (0-1), Qualcomm Oryon V3
	1: 6 processors (2-7),	1: 6 cores (2-7), Qualcomm Oryon V3
```
Like the original the Pheonix L vs M is minor differences - cache size, clockrate and 2 vector units versus 4 vector units.

Some lower level details:
```
device:
 - ro.product.device: "OP611FL1"
 - ro.product.name: "CPH2747"
 - ro.product.brand: "OnePlus"
 - ro.product.manufacturer: "OnePlus"
 - ro.product.model: "CPH2747"
 - ro.soc.manufacturer: "QTI"
 - ro.soc.model: "SM8850" processor:
 - chipset: "Unknown"
 - core: "Oryon V3"
 - MIDR: 0x512F0021
 ```
 Fixes #356