### PR TITLE
Add Apple SME isa and vector length detects

### DIFF
--- a/src/arm/mach/init.c
+++ b/src/arm/mach/init.c
@@ -449,7 +449,7 @@ void cpuinfo_arm_mach_init(void) {
 	}
 
 	cpuinfo_isa.i8mm = get_sys_info_by_name("hw.optional.arm.FEAT_I8MM") != 0;
-	cpuinfo_isa.sme= get_sys_info_by_name("hw.optional.arm.FEAT_SME") != 0;
+	cpuinfo_isa.sme = get_sys_info_by_name("hw.optional.arm.FEAT_SME") != 0;
 	cpuinfo_isa.sme2 = get_sys_info_by_name("hw.optional.arm.FEAT_SME2") != 0;
 	cpuinfo_isa.sme2p1 = get_sys_info_by_name("hw.optional.arm.FEAT_SME2p1") != 0;
 	cpuinfo_isa.sme_i16i32 = get_sys_info_by_name("hw.optional.arm.SME_I16I32") != 0;


### PR DESCRIPTION
Update src/mach/init.c to be have same detects as src/windows/init.c using sysctl to detect hw.optional.arm features

isa_info on Macbook M4
```
./isa_info 
SIMD extensions:
	ARM SVE: no
	ARM SVE 2: no
	ARM SME: yes
	ARM SME 2: yes
	ARM SME 2P1: no
	ARM SME I16I32: yes
	ARM SME BI32I32: yes
	ARM SME B16B16: no
	ARM SME F16F16: no
ARM SVE Capabilities:
	SVE max length: 0
	SME max length: 512
```

For comparison on Android with ARM Lumix C1
```SIMD extensions:
	ARM SVE: yes
	ARM SVE 2: yes
	ARM SME: yes
	ARM SME 2: yes
	ARM SME 2P1: no
	ARM SME I16I32: yes
	ARM SME BI32I32: yes
	ARM SME B16B16: no
	ARM SME F16F16: no
ARM SVE Capabilities:
	SVE max length: 128
	SME max length: 512
```

Apple Macbook M4 command prompt the features can be tested
```
sysctl -a | grep -i sme
kern.progressmeterenable: 0
kern.progressmeter: 33
hw.optional.arm.FEAT_SME: 1
hw.optional.arm.FEAT_SME2: 1
hw.optional.arm.FEAT_SME2p1: 0
hw.optional.arm.SME_F32F32: 1
hw.optional.arm.SME_BI32I32: 1
hw.optional.arm.SME_B16F32: 1
hw.optional.arm.SME_F16F32: 1
hw.optional.arm.SME_I8I32: 1
hw.optional.arm.SME_I16I32: 1
hw.optional.arm.FEAT_SME_F64F64: 1
hw.optional.arm.FEAT_SME_I16I64: 1
hw.optional.arm.FEAT_SME_F16F16: 0
hw.optional.arm.FEAT_SME_B16B16: 0
hw.optional.arm.sme_max_svl_b: 64
```

Fixes #362 