### PR TITLE
Add ARM Cortex A520 little core uarch

### DIFF
--- a/src/arm/linux/aarch32-isa.c
+++ b/src/arm/linux/aarch32-isa.c
@@ -69,6 +69,7 @@ void cpuinfo_arm_linux_decode_isa_from_proc_cpuinfo(
 		 * - Processors with Cortex-A77 cores
 		 * - Processors with Cortex-A78 cores
 		 * - Processors with Cortex-A510 cores
+		 * - Processors with Cortex-A520 cores
 		 * - Processors with Cortex-A710 cores
 		 * - Processors with Cortex-A715 cores
 		 * - Processors with Cortex-X1 cores

--- a/src/arm/midr.h
+++ b/src/arm/midr.h
@@ -221,6 +221,9 @@ inline static uint32_t midr_score_core(uint32_t midr) {
 		case UINT32_C(0x4100D030): /* Cortex-A53 */
 		case UINT32_C(0x4100D050): /* Cortex-A55 */
 		case UINT32_C(0x4100D460): /* Cortex-A510 */
+#if CPUINFO_ARCH_ARM64
+		case UINT32_C(0x4100D800): /* Cortex-A520 */
+#endif /* CPUINFO_ARCH_ARM64 */
 			/* Cortex-A53 is usually in LITTLE role, but can be in
 			 * big role w.r.t. Cortex-A35 */
 			return 2;

--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -126,6 +126,9 @@ void cpuinfo_arm_decode_vendor_uarch(
 				case 0xD4F: /* Neoverse V2 */
 					*uarch = cpuinfo_uarch_neoverse_v2;
 					break;
+				case 0xD80: /* Cortex-A520 */
+					*uarch = cpuinfo_uarch_cortex_a520;
+					break;
 				case 0xD81: /* Cortex-A720 */
 					*uarch = cpuinfo_uarch_cortex_a720;
 					break;

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -202,6 +202,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Cortex-A78";
 		case cpuinfo_uarch_cortex_a510:
 			return "Cortex-A510";
+		case cpuinfo_uarch_cortex_a520:
+			return "Cortex-A520";
 		case cpuinfo_uarch_cortex_a710:
 			return "Cortex-A710";
 		case cpuinfo_uarch_cortex_a715:


### PR DESCRIPTION
Example Samsung S24 sm-s921u

SoC name: Unknown
Microarchitectures:
	1x Cortex-X4
	5x Cortex-A720
	2x Cortex-A520
Cores:
	0: 1 processor (0), ARM Cortex-X4
	1: 1 processor (1), ARM Cortex-A720
	2: 1 processor (2), ARM Cortex-A720
	3: 1 processor (3), ARM Cortex-A720
	4: 1 processor (4), ARM Cortex-A720
	5: 1 processor (5), ARM Cortex-A720
	6: 1 processor (6), ARM Cortex-A520
	7: 1 processor (7), ARM Cortex-A520
Clusters:
	0: 1 processor (0),	0: 1 core (0), ARM Cortex-X4
	1: 3 processors (1-3),	1: 3 cores (1-3), ARM Cortex-A720
	2: 2 processors (4-5),	2: 2 cores (4-5), ARM Cortex-A720
	3: 2 processors (6-7),	3: 2 cores (6-7), ARM Cortex-A520
Logical processors (System ID):
	0 (7)
	1 (2)
	2 (3)
	3 (4)
	4 (5)
	5 (6)
	6 (0)
	7 (1)