### PR TITLE
Fix syscall() undeclared error if built with stricter build options

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1,3 +1,6 @@
+/* for syscall() */
+#define _DEFAULT_SOURCE
+
 #include <stdbool.h>
 #include <stddef.h>
 


### PR DESCRIPTION
If cpuinfo is built with a stricer build flags, it fails on some systems with the undeclared function error, because on Glibc syscall() is not a part of the headers unless one of the feature macros is defined. Add the least intrusive one, _DEFAULT_SOURCE.

cpuinfo/src/api.c:319:23: error: call to undeclared function 'syscall'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                if CPUINFO_UNLIKELY(syscall(__NR_getcpu, &cpu, NULL, NULL) != 0) {
                                    ^
cpuinfo/src/api.c:338:23: error: call to undeclared function 'syscall'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                if CPUINFO_UNLIKELY(syscall(__NR_getcpu, &cpu, NULL, NULL) != 0) {

Closes #171