### PR TITLE
arm/linux: zero-initialize stack buffers to fix Valgrind warnings

### DIFF
--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -256,12 +256,12 @@ void cpuinfo_arm_linux_init(void) {
 	}
 
 #if defined(__ANDROID__)
-	struct cpuinfo_android_properties android_properties;
+	struct cpuinfo_android_properties android_properties = {0};
 	cpuinfo_arm_android_parse_properties(&android_properties);
 #else
-	char proc_cpuinfo_hardware[CPUINFO_HARDWARE_VALUE_MAX];
+	char proc_cpuinfo_hardware[CPUINFO_HARDWARE_VALUE_MAX] = {0};
 #endif
-	char proc_cpuinfo_revision[CPUINFO_REVISION_VALUE_MAX];
+	char proc_cpuinfo_revision[CPUINFO_REVISION_VALUE_MAX] = {0};
 
 	if (!cpuinfo_arm_linux_parse_proc_cpuinfo(
 #if defined(__ANDROID__)


### PR DESCRIPTION
### Description
This PR fixes Valgrind and MemorySanitizer warnings caused by reading uninitialized stack memory.

**1. Bugfix:**
On modern AArch64 kernels, the "Hardware" line is often completely absent from `/proc/cpuinfo`. When this happens, the stack-allocated `proc_cpuinfo_hardware` buffer is never populated and may remains uninitialized garbage. Passing it to `strnlen` and `strncmp` in `cpuinfo_arm_linux_decode_chipset_from_proc_cpuinfo_hardware` triggers memory analyzer warnings. Adding `= {0}` ensures it safely defaults to an empty string `""` and fixes the issue.

**2. Follow-up hardening:**
To proactively prevent the exact same issue on other platforms (or Android) where OS-specific properties might be missing, I also zero-initialized the adjacent `proc_cpuinfo_revision` and `android_properties` buffers.

Since `cpuinfo_arm_linux_init` runs exactly once via `pthread_once`, the performance overhead of zeroing these bytes is negligible.

### Valgrind Trace
```text
==24496== Conditional jump or move depends on uninitialised value(s)
==24496==    at 0x4838B0C: strnlen (vg_replace_strmem.c:468)
==24496==    by 0x1B3CCFF: cpuinfo_arm_linux_decode_chipset_from_proc_cpuinfo_hardware
==24496==    by 0x1B3E24B: cpuinfo_arm_linux_decode_chipset
==24496==    by 0x1B3AC47: cpuinfo_arm_linux_init