### PR TITLE
Add Sapphire Rapids (Golden Cove) microarchitecture detection

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -357,6 +357,10 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_willow_cove = 0x0010020D,
 	/** Intel Golden Cove microarchitecture (Sapphire Rapids). */
 	cpuinfo_uarch_golden_cove = 0x0010020E,
+	/** Intel Raptor Cove microarchitecture (Emerald Rapids). */
+	cpuinfo_uarch_raptor_cove = 0x0010020F,
+	/** Intel Redwood Cove microarchitecture (Granite Rapids). */
+	cpuinfo_uarch_redwood_cove = 0x00100210,
 
 	/** Pentium 4 with Willamette, Northwood, or Foster cores. */
 	cpuinfo_uarch_willamette = 0x00100300,

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -355,6 +355,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_sunny_cove = 0x0010020C,
 	/** Intel Willow Cove microarchitecture (10 nm, Tiger Lake). */
 	cpuinfo_uarch_willow_cove = 0x0010020D,
+	/** Intel Golden Cove microarchitecture (Sapphire Rapids). */
+	cpuinfo_uarch_golden_cove = 0x0010020E,
 
 	/** Pentium 4 with Willamette, Northwood, or Foster cores. */
 	cpuinfo_uarch_willamette = 0x00100300,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -173,6 +173,10 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 							return cpuinfo_uarch_willow_cove;
 						case 0x8F: // Sapphire Rapids
 							return cpuinfo_uarch_golden_cove;
+						case 0xCF: // Emerald Rapids
+							return cpuinfo_uarch_raptor_cove;
+						case 0xAD: // Granite Rapids
+							return cpuinfo_uarch_redwood_cove;
 						/* Low-power cores */
 						case 0x1C: // Diamondville,
 							   // Silverthorne,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -171,6 +171,8 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 						case 0x8C: // Tiger U
 						case 0x8D: // Tiger H
 							return cpuinfo_uarch_willow_cove;
+						case 0x8F: // Sapphire Rapids
+							return cpuinfo_uarch_golden_cove;
 						/* Low-power cores */
 						case 0x1C: // Diamondville,
 							   // Silverthorne,

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -82,6 +82,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Sunny Cove";
 		case cpuinfo_uarch_willow_cove:
 			return "Willow Cove";
+		case cpuinfo_uarch_golden_cove:
+			return "Golden Cove";
 		case cpuinfo_uarch_willamette:
 			return "Willamette";
 		case cpuinfo_uarch_prescott:

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -84,6 +84,10 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Willow Cove";
 		case cpuinfo_uarch_golden_cove:
 			return "Golden Cove";
+		case cpuinfo_uarch_raptor_cove:
+			return "Raptor Cove";
+		case cpuinfo_uarch_redwood_cove:
+			return "Redwood Cove";
 		case cpuinfo_uarch_willamette:
 			return "Willamette";
 		case cpuinfo_uarch_prescott:


### PR DESCRIPTION
This PR adds CPU microarchitecture detection for:
- Sapphire Rapids (Golden Cove)
- Emerald Rapids (Raptor Cove)
- Granite Rapids (Redwood Cove)

Tested with Intel Software Development Emulator (SDE) 10.8.

**Sapphire Rapids (`sde64 -spr -- ./cpu-info`)**
```
Packages:
	0: Intel 0000%
Microarchitectures:
	36x Golden Cove
Cores:
	0: 2 processors (0-1), Intel Golden Cove
	1: 2 processors (2-3), Intel Golden Cove
...
```

**Emerald Rapids (`sde64 -emr -- ./cpu-info`)**
```
Packages:
	0: Intel 0000%
Microarchitectures:
	36x Raptor Cove
Cores:
	0: 2 processors (0-1), Intel Raptor Cove
	1: 2 processors (2-3), Intel Raptor Cove
...
```

**Granite Rapids (`sde64 -gnr -- ./cpu-info`)**
```
Packages:
	0: 
	1: 
	2: 
	3: 
Microarchitectures:
	36x Redwood Cove
Cores:
	0: 2 processors (0-1), Intel Redwood Cove
	1: 2 processors (2-3), Intel Redwood Cove
...
```