### PR TITLE
Add Cortex-A320 to MIDR decode table

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -525,6 +525,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_cortex_a510 = 0x00300551,
 	/** ARM Cortex-A520. */
 	cpuinfo_uarch_cortex_a520 = 0x00300552,
+	/** ARM Cortex-A320. */
+	cpuinfo_uarch_cortex_a320 = 0x00300553,
 	/** ARM Cortex-A710. */
 	cpuinfo_uarch_cortex_a710 = 0x00300571,
 	/** ARM Cortex-A715. */

--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -141,6 +141,9 @@ void cpuinfo_arm_decode_vendor_uarch(
 				case 0xD87: /* Cortex-A725 */
 					*uarch = cpuinfo_uarch_cortex_a725;
 					break;
+				case 0xD8F: /* Cortex-A320 */
+					*uarch = cpuinfo_uarch_cortex_a320;
+					break;
 				case 0xD8C:
 					*uarch = cpuinfo_uarch_lumex_c1_ultra;
 					break;


### PR DESCRIPTION
Based on https://github.com/pytorch/cpuinfo/pull/379 but only keeps the uarch cpuinfo_uarch_cortex_a320 changes in src/arm/uarch.c and include/cpuinfo.h.

Co-authored-by: Nicolas Pitre <npitre@baylibre.com>