### PR TITLE
Add Cortex-A320 to MIDR decode table

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -525,6 +525,8 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_cortex_a510 = 0x00300551,
 	/** ARM Cortex-A520. */
 	cpuinfo_uarch_cortex_a520 = 0x00300552,
+	/** ARM Cortex-A320. */
+	cpuinfo_uarch_cortex_a320 = 0x00300553,
 	/** ARM Cortex-A710. */
 	cpuinfo_uarch_cortex_a710 = 0x00300571,
 	/** ARM Cortex-A715. */

--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -141,17 +141,20 @@ void cpuinfo_arm_decode_vendor_uarch(
 				case 0xD87: /* Cortex-A725 */
 					*uarch = cpuinfo_uarch_cortex_a725;
 					break;
-				case 0xD8C:
-					*uarch = cpuinfo_uarch_lumex_c1_ultra;
-					break;
-				case 0xD90:
-					*uarch = cpuinfo_uarch_lumex_c1_premium;
+				case 0xD8A:
+					*uarch = cpuinfo_uarch_lumex_c1_nano;
 					break;
 				case 0xD8B:
 					*uarch = cpuinfo_uarch_lumex_c1_pro;
 					break;
-				case 0xD8A:
-					*uarch = cpuinfo_uarch_lumex_c1_nano;
+				case 0xD8C:
+					*uarch = cpuinfo_uarch_lumex_c1_ultra;
+					break;
+				case 0xD8F: /* Cortex-A320 */
+					*uarch = cpuinfo_uarch_cortex_a320;
+					break;
+				case 0xD90:
+					*uarch = cpuinfo_uarch_lumex_c1_premium;
 					break;
 				default:
 					switch (midr_get_part(midr) >> 8) {

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -212,6 +212,8 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Cortex-A510";
 		case cpuinfo_uarch_cortex_a520:
 			return "Cortex-A520";
+		case cpuinfo_uarch_cortex_a320:
+			return "Cortex-A320";
 		case cpuinfo_uarch_cortex_a710:
 			return "Cortex-A710";
 		case cpuinfo_uarch_cortex_a715:


### PR DESCRIPTION
Split out from #379 per review request.

ARM Cortex-A320 (MIDR part `0xD8F`) is an ARMv9.2-A efficiency core.
Add its uarch enum value and MIDR decode entry so consumers (XNNPACK,
KleidiAI, etc.) can dispatch optimised kernels when running on this
core.

The A320 implements the ARMv9.2-A mandatory feature set: NEON, SVE2,
dotprod, FP16, BF16, I8MM (per the [Cortex-A320 TRM][trm]).

The new MIDR/uarch entries are inserted in numerical order alongside
the existing ARMv9 cores added by recent commits (A520, A720, X4,
X925, A725, Lumex variants).

[trm]: https://developer.arm.com/Processors/Cortex-A320