### PR TITLE
Add Apple M1/M2/M3/M4 Linux MIDR detection

### DIFF
--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -438,6 +438,35 @@ void cpuinfo_arm_decode_vendor_uarch(
 						midr_get_part(midr));
 			}
 			break;
+		case 'a':
+			*vendor = cpuinfo_vendor_apple;
+			switch (midr_get_part(midr)) {
+				case 0x022:
+				case 0x024:
+				case 0x028:
+					*uarch = cpuinfo_uarch_icestorm;
+					break;
+				case 0x023:
+				case 0x025:
+				case 0x029:
+					*uarch = cpuinfo_uarch_firestorm;
+					break;
+				case 0x032:
+				case 0x034:
+				case 0x038:
+					*uarch = cpuinfo_uarch_blizzard;
+					break;
+				case 0x033:
+				case 0x035:
+				case 0x039:
+					*uarch = cpuinfo_uarch_avalanche;
+					break;
+				default:
+					cpuinfo_log_warning(
+						"unknown Apple CPU part 0x%03" PRIx32 " ignored",
+						midr_get_part(midr));
+			}
+			break;
 #if CPUINFO_ARCH_ARM
 		case 'V':
 			*vendor = cpuinfo_vendor_marvell;

--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -461,6 +461,22 @@ void cpuinfo_arm_decode_vendor_uarch(
 				case 0x039:
 					*uarch = cpuinfo_uarch_avalanche;
 					break;
+				case 0x042:
+				case 0x044:
+				case 0x048:
+					*uarch = cpuinfo_uarch_coll_sawtooth;
+					break;
+				case 0x043:
+				case 0x045:
+				case 0x049:
+					*uarch = cpuinfo_uarch_coll_everest;
+					break;
+				case 0x052:
+					*uarch = cpuinfo_uarch_donan_sawtooth;
+					break;
+				case 0x053:
+					*uarch = cpuinfo_uarch_donan_everest;
+					break;
 				default:
 					cpuinfo_log_warning(
 						"unknown Apple CPU part 0x%03" PRIx32 " ignored",

--- a/src/arm/uarch.c
+++ b/src/arm/uarch.c
@@ -479,8 +479,7 @@ void cpuinfo_arm_decode_vendor_uarch(
 					break;
 				default:
 					cpuinfo_log_warning(
-						"unknown Apple CPU part 0x%03" PRIx32 " ignored",
-						midr_get_part(midr));
+						"unknown Apple CPU part 0x%03" PRIx32 " ignored", midr_get_part(midr));
 			}
 			break;
 #if CPUINFO_ARCH_ARM


### PR DESCRIPTION
Fixes #380 by adding `cpuinfo_arm_decode_vendor_uarch` logic for Apple's implementer `'a'` (0x61).

This PR includes MIDR part mappings for:
- **M1**: Icestorm / Firestorm (0x022, 0x023, 0x024, 0x025, 0x028, 0x029)
- **M2**: Blizzard / Avalanche (0x032, 0x033, 0x034, 0x035, 0x038, 0x039)
- **M3**: Sawtooth / Everest (0x042, 0x043, 0x044, 0x045, 0x048, 0x049)
- **M4**: Donan Sawtooth / Donan Everest (0x052, 0x053)

These additions allow `cpuinfo` to correctly detect the microarchitecture of Apple Silicon cores when running on Linux (e.g., Asahi Linux).