### PR TITLE
Normalization of AMD brand string with "with Radeon Graphics"

### DIFF
--- a/src/x86/name.c
+++ b/src/x86/name.c
@@ -307,6 +307,15 @@ static bool transform_token(char* token_start, char* token_end, struct parser_st
 			}
 			break;
 		case 4:
+			/*
+			 * Erase everything starting with "with" on AMD
+			 * processors, e.g. "AMD Ryzen 5 PRO 6650U with Radeon
+			 * Graphics"
+			 */
+			if (erase_matching(token_start, token_length, "with")) {
+				return false;
+			}
+
 			/* Remember to erase "Dual Core" in "AMD Athlon(tm) 64
 			 * X2 Dual Core Processor 3800+" */
 			if (memcmp(token_start, "Dual", token_length) == 0) {

--- a/test/name/brand-string.cc
+++ b/test/name/brand-string.cc
@@ -328,6 +328,7 @@ TEST(BRAND_STRING, amd) {
 		"Phenom II X6 1055T",
 		normalize_brand_string("AMD Phenom(tm) II X6 1055T Processor\0\0\0\0\0\0\0\0\0\0\0\0"));
 	EXPECT_EQ("Ryzen 5 1500X", normalize_brand_string("AMD Ryzen 5 1500X Quad-Core Processor          \0"));
+	EXPECT_EQ("Ryzen 5 PRO 6650U", normalize_brand_string("AMD Ryzen 5 PRO 6650U with Radeon Graphics     \0"));
 	EXPECT_EQ("Ryzen 7 1700X", normalize_brand_string("AMD Ryzen 7 1700X Eight-Core Processor         \0"));
 	EXPECT_EQ("Ryzen 7 1800X", normalize_brand_string("AMD Ryzen 7 1800X Eight-Core Processor         \0"));
 	EXPECT_EQ(


### PR DESCRIPTION
Some AMD processors with integrated graphics have "with Radeon Graphics" in the cpuid brand string without being preceded by other tokens like "SOC" or "APU" that are already used to erase the string. With the current logic, everything starting with "Radeon" is erased, leading to less than ideal results. Add a check for a "with" token and erase everything starting with that.

Running cpu-info before:

Packages:
        0: AMD Ryzen 5 PRO 6650U with

and after:

Packages:
        0: AMD Ryzen 5 PRO 6650U

There are plenty of other examples at
https://github.com/InstLatx64/InstLatx64/tree/master/AuthenticAMD