### PR TITLE
fix: remove unused import 'string' in android-device-dump.py

### DIFF
--- a/scripts/android-device-dump.py
+++ b/scripts/android-device-dump.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import string
 import argparse
 import subprocess
 import tempfile


### PR DESCRIPTION
Fixes #390