### PR TITLE
Add Nova Lake (Coyote Cove) uarch support

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -364,7 +364,6 @@ enum cpuinfo_uarch {
 	/** Intel Coyote Cove microarchitecture. */
 	cpuinfo_uarch_coyote_cove = 0x00100211,
 
-
 	/** Pentium 4 with Willamette, Northwood, or Foster cores. */
 	cpuinfo_uarch_willamette = 0x00100300,
 	/** Pentium 4 with Prescott and later cores. */

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -361,6 +361,9 @@ enum cpuinfo_uarch {
 	cpuinfo_uarch_raptor_cove = 0x0010020F,
 	/** Intel Redwood Cove microarchitecture (Granite Rapids). */
 	cpuinfo_uarch_redwood_cove = 0x00100210,
+	/** Intel Coyote Cove microarchitecture. */
+	cpuinfo_uarch_coyote_cove = 0x00100211,
+
 
 	/** Pentium 4 with Willamette, Northwood, or Foster cores. */
 	cpuinfo_uarch_willamette = 0x00100300,

--- a/src/x86/uarch.c
+++ b/src/x86/uarch.c
@@ -270,8 +270,15 @@ enum cpuinfo_uarch cpuinfo_x86_decode_uarch(
 							return cpuinfo_uarch_prescott;
 					}
 					break;
+				case 0x12:
+					switch (model_info->model) {
+						case 0x01: // Nova Lake P-core (Coyote Cove)
+							return cpuinfo_uarch_coyote_cove;
+					}
+					break;
 			}
 			break;
+
 		case cpuinfo_vendor_amd:
 			switch (model_info->family) {
 #if CPUINFO_ARCH_X86

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -88,6 +88,9 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 			return "Raptor Cove";
 		case cpuinfo_uarch_redwood_cove:
 			return "Redwood Cove";
+		case cpuinfo_uarch_coyote_cove:
+			return "Coyote Cove";
+
 		case cpuinfo_uarch_willamette:
 			return "Willamette";
 		case cpuinfo_uarch_prescott:


### PR DESCRIPTION
This PR adds support for Intel Nova Lake P-cores (Coyote Cove microarchitecture). Matches CPUID Family 18 (0x12), Model 1 (0x01) as emulated by Intel SDE (-nvl). Resolves #392.