### PR TITLE
riscv/linux: complete ISA extension, vendor/uarch, and cache support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -110,6 +110,7 @@ LINUX_RISCV_SRCS = [
     "src/riscv/linux/init.c",
     "src/riscv/linux/riscv-isa.c",
     "src/riscv/linux/riscv-hw.c",
+    "src/riscv/linux/cache.c",
 ]
 
 ANDROID_ARM_SRCS = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,8 @@ IF(CPUINFO_SUPPORTED_PLATFORM)
       LIST(APPEND CPUINFO_SRCS
         src/riscv/linux/init.c
 	src/riscv/linux/riscv-hw.c
-	src/riscv/linux/riscv-isa.c)
+	src/riscv/linux/riscv-isa.c
+	src/riscv/linux/cache.c)
     ENDIF()
   ENDIF()
 

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -224,6 +224,11 @@ enum cpuinfo_vendor {
 	cpuinfo_vendor_hygon = 16,
 	/** SiFive, Inc. Vendor of RISC-V processor microarchitectures. */
 	cpuinfo_vendor_sifive = 17,
+	/** T-Head Semiconductor Co., Ltd (Alibaba). Vendor of RISC-V processor
+	   microarchitectures. */
+	cpuinfo_vendor_thead = 18,
+	/** SpacemiT. Vendor of RISC-V processor microarchitectures. */
+	cpuinfo_vendor_spacemit = 19,
 
 	/* Active vendors of embedded CPUs */
 
@@ -666,6 +671,17 @@ enum cpuinfo_uarch {
 
 	/** HiSilicon TaiShan v110 (Huawei Kunpeng 920 series processors). */
 	cpuinfo_uarch_taishan_v110 = 0x00C00100,
+
+	/** SiFive 7-series (U74, U54, S7, S51). */
+	cpuinfo_uarch_sifive_7_series = 0x01100100,
+
+	/** T-Head C9xx series (C906, C910, C920). */
+	cpuinfo_uarch_thead_c9xx = 0x01200100,
+	/** T-Head C908. */
+	cpuinfo_uarch_thead_c908 = 0x01200101,
+
+	/** SpacemiT X60. */
+	cpuinfo_uarch_spacemit_x60 = 0x01400100,
 };
 
 struct cpuinfo_processor {
@@ -2240,8 +2256,45 @@ struct cpuinfo_riscv_isa {
 	/* ISA Extensions */
 	/* Half-Precision Floating-Point Extension. */
 	bool zfh;
+	/* Half-Precision Floating-Point Minimum Extension. */
+	bool zfhmin;
 	/* Half-Precision Floating-Point Vector Extension. */
 	bool zvfh;
+
+	/* Bit Manipulation Extensions */
+	bool zba;
+	bool zbb;
+	bool zbs;
+	bool zbc;
+
+	/* Scalar Crypto Extensions */
+	bool zbkb;
+	bool zbkc;
+	bool zbkx;
+	bool zknd;
+	bool zkne;
+	bool zknh;
+	bool zksed;
+	bool zksh;
+	bool zkt;
+
+	/* Vector Crypto Extensions */
+	bool zvbb;
+	bool zvbc;
+	bool zvkb;
+	bool zvkg;
+	bool zvkned;
+	bool zvknha;
+	bool zvknhb;
+	bool zvksed;
+	bool zvksh;
+	bool zvkt;
+
+	/* Cache Management Extension */
+	bool zicboz;
+
+	/* Non-Temporal Loads/Stores Hint Extension */
+	bool zihintntl;
 };
 
 extern struct cpuinfo_riscv_isa cpuinfo_isa;
@@ -2328,6 +2381,214 @@ static inline bool cpuinfo_has_riscv_zfh(void) {
 static inline bool cpuinfo_has_riscv_zvfh(void) {
 #if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 	return cpuinfo_isa.zvfh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zfhmin(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zfhmin;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zba(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zba;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbs(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbs;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbc(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbc;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbkb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbkb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbkc(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbkc;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbkx(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbkx;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zknd(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zknd;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zkne(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zkne;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zknh(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zknh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zksed(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zksed;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zksh(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zksh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zkt(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zkt;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvbb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvbb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvbc(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvbc;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkg(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkg;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkned(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkned;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvknha(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvknha;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvknhb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvknhb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvksed(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvksed;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvksh(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvksh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkt(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkt;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zicboz(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zicboz;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zihintntl(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zihintntl;
 #else
 	return false;
 #endif

--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -224,6 +224,11 @@ enum cpuinfo_vendor {
 	cpuinfo_vendor_hygon = 16,
 	/** SiFive, Inc. Vendor of RISC-V processor microarchitectures. */
 	cpuinfo_vendor_sifive = 17,
+	/** T-Head Semiconductor Co., Ltd (Alibaba). Vendor of RISC-V processor
+	   microarchitectures. */
+	cpuinfo_vendor_thead = 18,
+	/** SpacemiT. Vendor of RISC-V processor microarchitectures. */
+	cpuinfo_vendor_spacemit = 19,
 
 	/* Active vendors of embedded CPUs */
 
@@ -671,6 +676,17 @@ enum cpuinfo_uarch {
 
 	/** HiSilicon TaiShan v110 (Huawei Kunpeng 920 series processors). */
 	cpuinfo_uarch_taishan_v110 = 0x00C00100,
+
+	/** SiFive 7-series (U74, U54, S7, S51). */
+	cpuinfo_uarch_sifive_7_series = 0x01100100,
+
+	/** T-Head C9xx series (C906, C910, C920). */
+	cpuinfo_uarch_thead_c9xx = 0x01200100,
+	/** T-Head C908. */
+	cpuinfo_uarch_thead_c908 = 0x01200101,
+
+	/** SpacemiT X60. */
+	cpuinfo_uarch_spacemit_x60 = 0x01400100,
 };
 
 struct cpuinfo_processor {
@@ -2285,8 +2301,45 @@ struct cpuinfo_riscv_isa {
 	/* ISA Extensions */
 	/* Half-Precision Floating-Point Extension. */
 	bool zfh;
+	/* Half-Precision Floating-Point Minimum Extension. */
+	bool zfhmin;
 	/* Half-Precision Floating-Point Vector Extension. */
 	bool zvfh;
+
+	/* Bit Manipulation Extensions */
+	bool zba;
+	bool zbb;
+	bool zbs;
+	bool zbc;
+
+	/* Scalar Crypto Extensions */
+	bool zbkb;
+	bool zbkc;
+	bool zbkx;
+	bool zknd;
+	bool zkne;
+	bool zknh;
+	bool zksed;
+	bool zksh;
+	bool zkt;
+
+	/* Vector Crypto Extensions */
+	bool zvbb;
+	bool zvbc;
+	bool zvkb;
+	bool zvkg;
+	bool zvkned;
+	bool zvknha;
+	bool zvknhb;
+	bool zvksed;
+	bool zvksh;
+	bool zvkt;
+
+	/* Cache Management Extension */
+	bool zicboz;
+
+	/* Non-Temporal Loads/Stores Hint Extension */
+	bool zihintntl;
 };
 
 extern struct cpuinfo_riscv_isa cpuinfo_isa;
@@ -2373,6 +2426,214 @@ static inline bool cpuinfo_has_riscv_zfh(void) {
 static inline bool cpuinfo_has_riscv_zvfh(void) {
 #if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
 	return cpuinfo_isa.zvfh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zfhmin(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zfhmin;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zba(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zba;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbs(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbs;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbc(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbc;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbkb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbkb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbkc(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbkc;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zbkx(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zbkx;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zknd(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zknd;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zkne(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zkne;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zknh(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zknh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zksed(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zksed;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zksh(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zksh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zkt(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zkt;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvbb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvbb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvbc(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvbc;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkg(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkg;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkned(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkned;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvknha(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvknha;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvknhb(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvknhb;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvksed(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvksed;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvksh(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvksh;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zvkt(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zvkt;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zicboz(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zicboz;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_riscv_zihintntl(void) {
+#if CPUINFO_ARCH_RISCV32 || CPUINFO_ARCH_RISCV64
+	return cpuinfo_isa.zihintntl;
 #else
 	return false;
 #endif

--- a/src/riscv/api.h
+++ b/src/riscv/api.h
@@ -5,23 +5,22 @@
 #include <cpuinfo.h>
 #include <cpuinfo/common.h>
 
-/* RISC-V Vendor IDs. */
+/* RISC-V Vendor IDs (mvendorid CSR). */
 enum cpuinfo_riscv_chipset_vendor {
 	cpuinfo_riscv_chipset_vendor_unknown = 0,
 	cpuinfo_riscv_chipset_vendor_sifive = 0x489,
+	cpuinfo_riscv_chipset_vendor_thead = 0x5b7,
+	cpuinfo_riscv_chipset_vendor_spacemit = 0x61f,
 	cpuinfo_riscv_chipset_vendor_max,
 };
 
-/* RISC-V Architecture IDs. */
+/*
+ * RISC-V Architecture IDs (marchid CSR).
+ * Bit 63 set indicates a commercial implementation.
+ */
 enum cpuinfo_riscv_chipset_arch {
 	cpuinfo_riscv_chipset_arch_unknown = 0,
 	cpuinfo_riscv_chipset_arch_max,
-};
-
-/* RISC-V Implementation IDs. */
-enum cpuinfo_riscv_chipset_impl {
-	cpuinfo_riscv_chipset_impl_unknown = 0,
-	cpuinfo_riscv_chipset_impl_max,
 };
 
 /**
@@ -35,8 +34,8 @@ enum cpuinfo_riscv_chipset_impl {
  * @param[uarch] - Reference to the cpuinfo_uarch to populate.
  */
 CPUINFO_INTERNAL void cpuinfo_riscv_decode_vendor_uarch(
-	uint32_t vendor_id,
-	uint32_t arch_id,
-	uint32_t imp_id,
+	uint64_t vendor_id,
+	uint64_t arch_id,
+	uint64_t imp_id,
 	enum cpuinfo_vendor vendor[restrict static 1],
 	enum cpuinfo_uarch uarch[restrict static 1]);

--- a/src/riscv/linux/api.h
+++ b/src/riscv/linux/api.h
@@ -69,5 +69,33 @@ CPUINFO_INTERNAL void cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
 	enum cpuinfo_uarch uarch[restrict static 1],
 	struct cpuinfo_riscv_isa isa[restrict static 1]);
 
+/**
+ * Reads sysfs cache topology for a given CPU and populates cache structures.
+ * Returns true if any cache information was found.
+ */
+CPUINFO_INTERNAL bool cpuinfo_riscv_linux_parse_cache_from_sysfs(
+	uint32_t cpu_id,
+	struct cpuinfo_cache l1i[restrict static 1],
+	struct cpuinfo_cache l1d[restrict static 1],
+	struct cpuinfo_cache l2[restrict static 1],
+	struct cpuinfo_cache l3[restrict static 1]);
+
+/**
+ * Information about cache sharing topology for a given cache level.
+ */
+struct cpuinfo_riscv_cache_sharing_info {
+	uint32_t min_cpu;
+	uint32_t cpu_count;
+};
+
+/**
+ * Gets cache sharing information for the cache at the given level.
+ * Returns true if the cache level exists for the given CPU.
+ */
+CPUINFO_INTERNAL bool cpuinfo_riscv_linux_get_cache_sharing(
+	uint32_t cpu_id,
+	uint32_t cache_level,
+	struct cpuinfo_riscv_cache_sharing_info sharing[restrict static 1]);
+
 /* Used to determine which uarch is associated with the current thread. */
 extern CPUINFO_INTERNAL const uint32_t* cpuinfo_linux_cpu_to_uarch_index_map;

--- a/src/riscv/linux/cache.c
+++ b/src/riscv/linux/cache.c
@@ -1,0 +1,291 @@
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <cpuinfo.h>
+#include <cpuinfo/log.h>
+#include <linux/api.h>
+#include <riscv/linux/api.h>
+
+static bool uint32_parser(
+	const char* filename,
+	const char* text_start,
+	const char* text_end,
+	void* context) {
+	uint32_t* value_ptr = (uint32_t*)context;
+	if (text_start == text_end) {
+		return false;
+	}
+	uint32_t value = 0;
+	const char* p = text_start;
+	for (; p < text_end && *p >= '0' && *p <= '9'; p++) {
+		value = value * 10 + (*p - '0');
+	}
+	if (p == text_start) {
+		return false;
+	}
+	*value_ptr = value;
+	return true;
+}
+
+static bool cache_size_parser(
+	const char* filename,
+	const char* text_start,
+	const char* text_end,
+	void* context) {
+	uint32_t* size_ptr = (uint32_t*)context;
+	if (text_start == text_end) {
+		return false;
+	}
+	uint32_t value = 0;
+	const char* p = text_start;
+	while (p < text_end && *p >= '0' && *p <= '9') {
+		value = value * 10 + (*p - '0');
+		p++;
+	}
+	if (p == text_start || value == 0) {
+		return false;
+	}
+	uint32_t multiplier = 1024;
+	if (p < text_end) {
+		const char c = (char)toupper((unsigned char)*p);
+		if (c == 'M') {
+			multiplier = 1024 * 1024;
+		} else if (c == 'G') {
+			multiplier = 1024 * 1024 * 1024;
+		}
+	}
+	*size_ptr = value * multiplier;
+	return true;
+}
+
+struct cache_type_context {
+	bool is_instruction;
+	bool is_data;
+	bool is_unified;
+};
+
+static bool cache_type_parser(
+	const char* filename,
+	const char* text_start,
+	const char* text_end,
+	void* context) {
+	struct cache_type_context* type = (struct cache_type_context*)context;
+	if (text_end - text_start >= 11 && memcmp(text_start, "Instruction", 11) == 0) {
+		type->is_instruction = true;
+	} else if (text_end - text_start >= 7 && memcmp(text_start, "Unified", 7) == 0) {
+		type->is_unified = true;
+	} else if (text_end - text_start >= 4 && memcmp(text_start, "Data", 4) == 0) {
+		type->is_data = true;
+	}
+	return true;
+}
+
+/*
+ * Find the sysfs cache index for a given cpu, level, and type.
+ * Type must be "Instruction", "Data", or "Unified" (exact match).
+ * Returns the sysfs index, or UINT32_MAX if not found.
+ */
+static uint32_t find_cache_index(
+	uint32_t cpu_id,
+	uint32_t level,
+	const char* type) {
+	char path[256];
+	for (uint32_t idx = 0; idx < 8; idx++) {
+		snprintf(
+			path,
+			sizeof(path),
+			"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/level",
+			cpu_id,
+			idx);
+		uint32_t actual_level = 0;
+		if (!cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &actual_level)) {
+			break;
+		}
+		if (actual_level != level) {
+			continue;
+		}
+
+		snprintf(
+			path,
+			sizeof(path),
+			"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/type",
+			cpu_id,
+			idx);
+		struct cache_type_context ctx = {0};
+		if (!cpuinfo_linux_parse_small_file(path, 32, cache_type_parser, &ctx)) {
+			continue;
+		}
+
+		if ((strcmp(type, "Instruction") == 0 && ctx.is_instruction) ||
+		    (strcmp(type, "Data") == 0 && ctx.is_data) ||
+		    (strcmp(type, "Unified") == 0 && ctx.is_unified)) {
+			return idx;
+		}
+	}
+	return UINT32_MAX;
+}
+
+/*
+ * Read cache properties from sysfs for a given cpu and cache index.
+ * Returns true if at least the size was successfully read.
+ */
+static bool read_cache_properties(
+	uint32_t cpu_id,
+	uint32_t cache_index,
+	struct cpuinfo_cache cache[restrict static 1]) {
+	char path[256];
+
+	uint32_t size = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/size",
+		cpu_id,
+		cache_index);
+	if (!cpuinfo_linux_parse_small_file(path, 32, cache_size_parser, &size) || size == 0) {
+		return false;
+	}
+	cache->size = size;
+
+	uint32_t line_size = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/coherency_line_size",
+		cpu_id,
+		cache_index);
+	cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &line_size);
+	cache->line_size = line_size;
+
+	uint32_t sets = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/number_of_sets",
+		cpu_id,
+		cache_index);
+	cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &sets);
+	cache->sets = sets;
+
+	uint32_t associativity = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/ways_of_associativity",
+		cpu_id,
+		cache_index);
+	cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &associativity);
+	cache->associativity = associativity;
+
+	cache->partitions = 1;
+	return true;
+}
+
+static bool sharing_info_callback(
+	uint32_t range_start,
+	uint32_t range_end,
+	void* context) {
+	struct cpuinfo_riscv_cache_sharing_info* info =
+		(struct cpuinfo_riscv_cache_sharing_info*)context;
+	if (range_start < info->min_cpu) {
+		info->min_cpu = range_start;
+	}
+	info->cpu_count += range_end - range_start;
+	return true;
+}
+
+bool cpuinfo_riscv_linux_parse_cache_from_sysfs(
+	uint32_t cpu_id,
+	struct cpuinfo_cache l1i[restrict static 1],
+	struct cpuinfo_cache l1d[restrict static 1],
+	struct cpuinfo_cache l2[restrict static 1],
+	struct cpuinfo_cache l3[restrict static 1]) {
+	bool found_any = false;
+	uint32_t idx;
+
+	/* L1 Instruction cache. */
+	idx = find_cache_index(cpu_id, 1, "Instruction");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l1i)) {
+		found_any = true;
+	}
+
+	/* L1 Data cache; fall back to Unified if no Data type exists. */
+	idx = find_cache_index(cpu_id, 1, "Data");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l1d)) {
+		found_any = true;
+	} else {
+		idx = find_cache_index(cpu_id, 1, "Unified");
+		if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l1d)) {
+			l1d->flags = CPUINFO_CACHE_UNIFIED;
+			found_any = true;
+		}
+	}
+
+	/* L2 cache: try Unified first, then Data. */
+	idx = find_cache_index(cpu_id, 2, "Unified");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l2)) {
+		l2->flags = CPUINFO_CACHE_UNIFIED;
+		found_any = true;
+	} else {
+		idx = find_cache_index(cpu_id, 2, "Data");
+		if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l2)) {
+			found_any = true;
+		}
+	}
+
+	/* L3 cache: try Unified first, then Data. */
+	idx = find_cache_index(cpu_id, 3, "Unified");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l3)) {
+		l3->flags = CPUINFO_CACHE_UNIFIED;
+		found_any = true;
+	} else {
+		idx = find_cache_index(cpu_id, 3, "Data");
+		if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l3)) {
+			found_any = true;
+		}
+	}
+
+	return found_any;
+}
+
+bool cpuinfo_riscv_linux_get_cache_sharing(
+	uint32_t cpu_id,
+	uint32_t cache_level,
+	struct cpuinfo_riscv_cache_sharing_info sharing[restrict static 1]) {
+	sharing->min_cpu = cpu_id;
+	sharing->cpu_count = 1;
+
+	/* Find any cache index at this level. */
+	uint32_t idx = find_cache_index(cpu_id, cache_level, "Unified");
+	if (idx == UINT32_MAX) {
+		idx = find_cache_index(cpu_id, cache_level, "Data");
+	}
+	if (idx == UINT32_MAX) {
+		idx = find_cache_index(cpu_id, cache_level, "Instruction");
+	}
+	if (idx == UINT32_MAX) {
+		return false;
+	}
+
+	char path[256];
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/shared_cpu_list",
+		cpu_id,
+		idx);
+
+	struct cpuinfo_riscv_cache_sharing_info info = {
+		.min_cpu = UINT32_MAX,
+		.cpu_count = 0,
+	};
+	if (cpuinfo_linux_parse_cpulist(path, sharing_info_callback, &info) &&
+	    info.cpu_count > 0) {
+		sharing->min_cpu = info.min_cpu;
+		sharing->cpu_count = info.cpu_count;
+	}
+	return true;
+}

--- a/src/riscv/linux/cache.c
+++ b/src/riscv/linux/cache.c
@@ -1,0 +1,301 @@
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <cpuinfo.h>
+#include <cpuinfo/log.h>
+#include <linux/api.h>
+#include <riscv/linux/api.h>
+
+static bool uint32_parser(
+	const char* filename,
+	const char* text_start,
+	const char* text_end,
+	void* context) {
+	uint32_t* value_ptr = (uint32_t*)context;
+	if (text_start == text_end) {
+		return false;
+	}
+	uint32_t value = 0;
+	const char* p = text_start;
+	for (; p < text_end && *p >= '0' && *p <= '9'; p++) {
+		value = value * 10 + (*p - '0');
+	}
+	if (p == text_start) {
+		return false;
+	}
+	*value_ptr = value;
+	return true;
+}
+
+static bool cache_size_parser(
+	const char* filename,
+	const char* text_start,
+	const char* text_end,
+	void* context) {
+	uint32_t* size_ptr = (uint32_t*)context;
+	if (text_start == text_end) {
+		return false;
+	}
+	uint32_t value = 0;
+	const char* p = text_start;
+	while (p < text_end && *p >= '0' && *p <= '9') {
+		value = value * 10 + (*p - '0');
+		p++;
+	}
+	if (p == text_start || value == 0) {
+		return false;
+	}
+	uint32_t multiplier = 1024;
+	if (p < text_end) {
+		const char c = (char)toupper((unsigned char)*p);
+		if (c == 'M') {
+			multiplier = 1024 * 1024;
+		} else if (c == 'G') {
+			multiplier = 1024 * 1024 * 1024;
+		}
+	}
+	*size_ptr = value * multiplier;
+	return true;
+}
+
+struct cache_type_context {
+	bool is_instruction;
+	bool is_data;
+	bool is_unified;
+};
+
+static bool cache_type_parser(
+	const char* filename,
+	const char* text_start,
+	const char* text_end,
+	void* context) {
+	struct cache_type_context* type = (struct cache_type_context*)context;
+	if (text_end - text_start >= 11 && memcmp(text_start, "Instruction", 11) == 0) {
+		type->is_instruction = true;
+	} else if (text_end - text_start >= 7 && memcmp(text_start, "Unified", 7) == 0) {
+		type->is_unified = true;
+	} else if (text_end - text_start >= 4 && memcmp(text_start, "Data", 4) == 0) {
+		type->is_data = true;
+	}
+	return true;
+}
+
+/*
+ * Find the sysfs cache index for a given cpu, level, and type.
+ * Type must be "Instruction", "Data", or "Unified" (exact match).
+ * Returns the sysfs index, or UINT32_MAX if not found.
+ */
+static uint32_t find_cache_index(
+	uint32_t cpu_id,
+	uint32_t level,
+	const char* type) {
+	char path[256];
+	for (uint32_t idx = 0; idx < 8; idx++) {
+		snprintf(
+			path,
+			sizeof(path),
+			"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/level",
+			cpu_id,
+			idx);
+		uint32_t actual_level = 0;
+		if (!cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &actual_level)) {
+			break;
+		}
+		if (actual_level != level) {
+			continue;
+		}
+
+		snprintf(
+			path,
+			sizeof(path),
+			"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/type",
+			cpu_id,
+			idx);
+		struct cache_type_context ctx = {0};
+		if (!cpuinfo_linux_parse_small_file(path, 32, cache_type_parser, &ctx)) {
+			continue;
+		}
+
+		if ((strcmp(type, "Instruction") == 0 && ctx.is_instruction) ||
+		    (strcmp(type, "Data") == 0 && ctx.is_data) ||
+		    (strcmp(type, "Unified") == 0 && ctx.is_unified)) {
+			return idx;
+		}
+	}
+	return UINT32_MAX;
+}
+
+/*
+ * Read cache properties from sysfs for a given cpu and cache index.
+ * Returns true if at least the size was successfully read.
+ */
+static bool read_cache_properties(
+	uint32_t cpu_id,
+	uint32_t cache_index,
+	struct cpuinfo_cache cache[restrict static 1]) {
+	char path[256];
+
+	uint32_t size = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/size",
+		cpu_id,
+		cache_index);
+	if (!cpuinfo_linux_parse_small_file(path, 32, cache_size_parser, &size) || size == 0) {
+		return false;
+	}
+	cache->size = size;
+
+	uint32_t line_size = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/coherency_line_size",
+		cpu_id,
+		cache_index);
+	cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &line_size);
+	cache->line_size = line_size;
+
+	uint32_t sets = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/number_of_sets",
+		cpu_id,
+		cache_index);
+	cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &sets);
+	cache->sets = sets;
+
+	uint32_t associativity = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/ways_of_associativity",
+		cpu_id,
+		cache_index);
+	cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &associativity);
+	cache->associativity = associativity;
+
+	uint32_t partitions = 0;
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/physical_line_partition",
+		cpu_id,
+		cache_index);
+	if (!cpuinfo_linux_parse_small_file(path, 16, uint32_parser, &partitions) || partitions == 0) {
+		partitions = 1;
+	}
+	cache->partitions = partitions;
+	return true;
+}
+
+static bool sharing_info_callback(
+	uint32_t range_start,
+	uint32_t range_end,
+	void* context) {
+	struct cpuinfo_riscv_cache_sharing_info* info =
+		(struct cpuinfo_riscv_cache_sharing_info*)context;
+	if (range_start < info->min_cpu) {
+		info->min_cpu = range_start;
+	}
+	info->cpu_count += range_end - range_start;
+	return true;
+}
+
+bool cpuinfo_riscv_linux_parse_cache_from_sysfs(
+	uint32_t cpu_id,
+	struct cpuinfo_cache l1i[restrict static 1],
+	struct cpuinfo_cache l1d[restrict static 1],
+	struct cpuinfo_cache l2[restrict static 1],
+	struct cpuinfo_cache l3[restrict static 1]) {
+	bool found_any = false;
+	uint32_t idx;
+
+	/* L1 Instruction cache. */
+	idx = find_cache_index(cpu_id, 1, "Instruction");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l1i)) {
+		found_any = true;
+	}
+
+	/* L1 Data cache; fall back to Unified if no Data type exists. */
+	idx = find_cache_index(cpu_id, 1, "Data");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l1d)) {
+		found_any = true;
+	} else {
+		idx = find_cache_index(cpu_id, 1, "Unified");
+		if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l1d)) {
+			l1d->flags = CPUINFO_CACHE_UNIFIED;
+			found_any = true;
+		}
+	}
+
+	/* L2 cache: try Unified first, then Data. */
+	idx = find_cache_index(cpu_id, 2, "Unified");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l2)) {
+		l2->flags = CPUINFO_CACHE_UNIFIED;
+		found_any = true;
+	} else {
+		idx = find_cache_index(cpu_id, 2, "Data");
+		if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l2)) {
+			found_any = true;
+		}
+	}
+
+	/* L3 cache: try Unified first, then Data. */
+	idx = find_cache_index(cpu_id, 3, "Unified");
+	if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l3)) {
+		l3->flags = CPUINFO_CACHE_UNIFIED;
+		found_any = true;
+	} else {
+		idx = find_cache_index(cpu_id, 3, "Data");
+		if (idx != UINT32_MAX && read_cache_properties(cpu_id, idx, l3)) {
+			found_any = true;
+		}
+	}
+
+	return found_any;
+}
+
+bool cpuinfo_riscv_linux_get_cache_sharing(
+	uint32_t cpu_id,
+	uint32_t cache_level,
+	struct cpuinfo_riscv_cache_sharing_info sharing[restrict static 1]) {
+	sharing->min_cpu = cpu_id;
+	sharing->cpu_count = 1;
+
+	/* Find any cache index at this level. */
+	uint32_t idx = find_cache_index(cpu_id, cache_level, "Unified");
+	if (idx == UINT32_MAX) {
+		idx = find_cache_index(cpu_id, cache_level, "Data");
+	}
+	if (idx == UINT32_MAX) {
+		idx = find_cache_index(cpu_id, cache_level, "Instruction");
+	}
+	if (idx == UINT32_MAX) {
+		return false;
+	}
+
+	char path[256];
+	snprintf(
+		path,
+		sizeof(path),
+		"/sys/devices/system/cpu/cpu%" PRIu32 "/cache/index%" PRIu32 "/shared_cpu_list",
+		cpu_id,
+		idx);
+
+	struct cpuinfo_riscv_cache_sharing_info info = {
+		.min_cpu = UINT32_MAX,
+		.cpu_count = 0,
+	};
+	if (cpuinfo_linux_parse_cpulist(path, sharing_info_callback, &info) &&
+	    info.cpu_count > 0) {
+		sharing->min_cpu = info.min_cpu;
+		sharing->cpu_count = info.cpu_count;
+	}
+	return true;
+}

--- a/src/riscv/linux/init.c
+++ b/src/riscv/linux/init.c
@@ -222,6 +222,18 @@ static bool package_cpus_parser(
 	return true;
 }
 
+struct riscv_cpu_cache_data {
+	struct cpuinfo_cache l1i;
+	struct cpuinfo_cache l1d;
+	struct cpuinfo_cache l2;
+	struct cpuinfo_cache l3;
+	struct cpuinfo_riscv_cache_sharing_info l2_sharing;
+	struct cpuinfo_riscv_cache_sharing_info l3_sharing;
+	uint32_t l2_group_index;
+	uint32_t l3_group_index;
+	bool has_caches;
+};
+
 /* Initialization for the RISC-V Linux system. */
 void cpuinfo_riscv_linux_init(void) {
 	struct cpuinfo_riscv_linux_processor* riscv_linux_processors = NULL;
@@ -230,6 +242,15 @@ void cpuinfo_riscv_linux_init(void) {
 	struct cpuinfo_cluster* clusters = NULL;
 	struct cpuinfo_core* cores = NULL;
 	struct cpuinfo_uarch_info* uarchs = NULL;
+	struct cpuinfo_cache* l1i = NULL;
+	struct cpuinfo_cache* l1d = NULL;
+	struct cpuinfo_cache* l2 = NULL;
+	struct cpuinfo_cache* l3 = NULL;
+	struct riscv_cpu_cache_data* cpu_caches = NULL;
+	uint32_t* l2_group_min_cpus = NULL;
+	uint32_t* l2_group_cpu_counts = NULL;
+	uint32_t* l3_group_min_cpus = NULL;
+	uint32_t* l3_group_cpu_counts = NULL;
 	const struct cpuinfo_processor** linux_cpu_to_processor_map = NULL;
 	const struct cpuinfo_core** linux_cpu_to_core_map = NULL;
 	uint32_t* linux_cpu_to_uarch_index_map = NULL;
@@ -374,6 +395,37 @@ void cpuinfo_riscv_linux_init(void) {
 	/* Populate ISA structure with hwcap information. */
 	cpuinfo_riscv_linux_decode_isa_from_hwcap(&cpuinfo_isa);
 
+	/*
+	 * Parse sysfs cache topology before qsort reorders the processor
+	 * array. At this point, array index == linux_id.
+	 */
+	cpu_caches = calloc(max_processor_id, sizeof(struct riscv_cpu_cache_data));
+	if (cpu_caches == NULL) {
+		cpuinfo_log_error("failed to allocate cpu cache data");
+		goto cleanup;
+	}
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		if (cpuinfo_riscv_linux_parse_cache_from_sysfs(
+				processor,
+				&cpu_caches[processor].l1i,
+				&cpu_caches[processor].l1d,
+				&cpu_caches[processor].l2,
+				&cpu_caches[processor].l3)) {
+			cpu_caches[processor].has_caches = true;
+		}
+		if (cpu_caches[processor].l2.size != 0) {
+			cpuinfo_riscv_linux_get_cache_sharing(
+				processor, 2, &cpu_caches[processor].l2_sharing);
+		}
+		if (cpu_caches[processor].l3.size != 0) {
+			cpuinfo_riscv_linux_get_cache_sharing(
+				processor, 3, &cpu_caches[processor].l3_sharing);
+		}
+	}
+
 	/**
 	 * To efficiently compute the number of unique micro-architectures
 	 * present on the system, sort the processor list by micro-architecture
@@ -504,12 +556,119 @@ void cpuinfo_riscv_linux_init(void) {
 		goto cleanup;
 	}
 
+	/*
+	 * Count cache entries from pre-parsed data. L1 caches are per-
+	 * processor; L2/L3 are deduplicated by shared_cpu_list min_cpu.
+	 */
+	uint32_t l1i_count = 0;
+	uint32_t l1d_count = 0;
+	uint32_t l2_count = 0;
+	uint32_t l3_count = 0;
+	bool has_caches = false;
+
+	l2_group_min_cpus = calloc(valid_processors_count, sizeof(uint32_t));
+	l2_group_cpu_counts = calloc(valid_processors_count, sizeof(uint32_t));
+	l3_group_min_cpus = calloc(valid_processors_count, sizeof(uint32_t));
+	l3_group_cpu_counts = calloc(valid_processors_count, sizeof(uint32_t));
+	if (l2_group_min_cpus == NULL || l2_group_cpu_counts == NULL ||
+	    l3_group_min_cpus == NULL || l3_group_cpu_counts == NULL) {
+		cpuinfo_log_error("failed to allocate cache group arrays");
+		goto cleanup;
+	}
+
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		uint32_t linux_id = riscv_linux_processors[processor].processor.linux_id;
+		if (cpu_caches[linux_id].has_caches) {
+			has_caches = true;
+		}
+		if (cpu_caches[linux_id].l1i.size != 0) {
+			l1i_count++;
+		}
+		if (cpu_caches[linux_id].l1d.size != 0) {
+			l1d_count++;
+		}
+		if (cpu_caches[linux_id].l2.size != 0) {
+			uint32_t min_cpu = cpu_caches[linux_id].l2_sharing.min_cpu;
+			uint32_t cpu_count = cpu_caches[linux_id].l2_sharing.cpu_count;
+			bool seen = false;
+			for (uint32_t j = 0; j < l2_count; j++) {
+				if (l2_group_min_cpus[j] == min_cpu &&
+				    l2_group_cpu_counts[j] == cpu_count) {
+					cpu_caches[linux_id].l2_group_index = j;
+					seen = true;
+					break;
+				}
+			}
+			if (!seen) {
+				l2_group_min_cpus[l2_count] = min_cpu;
+				l2_group_cpu_counts[l2_count] = cpu_count;
+				cpu_caches[linux_id].l2_group_index = l2_count;
+				l2_count++;
+			}
+		}
+		if (cpu_caches[linux_id].l3.size != 0) {
+			uint32_t min_cpu = cpu_caches[linux_id].l3_sharing.min_cpu;
+			uint32_t cpu_count = cpu_caches[linux_id].l3_sharing.cpu_count;
+			bool seen = false;
+			for (uint32_t j = 0; j < l3_count; j++) {
+				if (l3_group_min_cpus[j] == min_cpu &&
+				    l3_group_cpu_counts[j] == cpu_count) {
+					cpu_caches[linux_id].l3_group_index = j;
+					seen = true;
+					break;
+				}
+			}
+			if (!seen) {
+				l3_group_min_cpus[l3_count] = min_cpu;
+				l3_group_cpu_counts[l3_count] = cpu_count;
+				cpu_caches[linux_id].l3_group_index = l3_count;
+				l3_count++;
+			}
+		}
+	}
+
+	if (has_caches) {
+		if (l1i_count != 0) {
+			l1i = calloc(l1i_count, sizeof(struct cpuinfo_cache));
+			if (l1i == NULL) {
+				cpuinfo_log_error("failed to allocate L1I cache array");
+				goto cleanup;
+			}
+		}
+		if (l1d_count != 0) {
+			l1d = calloc(l1d_count, sizeof(struct cpuinfo_cache));
+			if (l1d == NULL) {
+				cpuinfo_log_error("failed to allocate L1D cache array");
+				goto cleanup;
+			}
+		}
+		if (l2_count != 0) {
+			l2 = calloc(l2_count, sizeof(struct cpuinfo_cache));
+			if (l2 == NULL) {
+				cpuinfo_log_error("failed to allocate L2 cache array");
+				goto cleanup;
+			}
+		}
+		if (l3_count != 0) {
+			l3 = calloc(l3_count, sizeof(struct cpuinfo_cache));
+			if (l3 == NULL) {
+				cpuinfo_log_error("failed to allocate L3 cache array");
+				goto cleanup;
+			}
+		}
+	}
+
 	/* Transfer contents of processor list to ABI structures. */
 	size_t valid_processors_index = 0;
 	size_t valid_cores_index = 0;
 	size_t valid_clusters_index = 0;
 	size_t valid_packages_index = 0;
 	size_t valid_uarchs_index = 0;
+	uint32_t l1i_index = 0;
+	uint32_t l1d_index = 0;
 	last_uarch = cpuinfo_uarch_unknown;
 	for (size_t processor = 0; processor < max_processor_id; processor++) {
 		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
@@ -571,6 +730,53 @@ void cpuinfo_riscv_linux_init(void) {
 
 		clusters[valid_clusters_index - 1].package = &packages[valid_packages_index - 1];
 
+		/* Populate cache from pre-parsed sysfs data. */
+		if (has_caches) {
+			const uint32_t pi = valid_processors_index - 1;
+			struct riscv_cpu_cache_data* cd = &cpu_caches[linux_id];
+
+			if (cd->l1i.size != 0 && l1i != NULL) {
+				l1i[l1i_index] = cd->l1i;
+				l1i[l1i_index].processor_start = pi;
+				l1i[l1i_index].processor_count = 1;
+				processors[pi].cache.l1i = &l1i[l1i_index];
+				l1i_index++;
+			}
+			if (cd->l1d.size != 0 && l1d != NULL) {
+				l1d[l1d_index] = cd->l1d;
+				l1d[l1d_index].processor_start = pi;
+				l1d[l1d_index].processor_count = 1;
+				processors[pi].cache.l1d = &l1d[l1d_index];
+				l1d_index++;
+			}
+			if (cd->l2.size != 0 && l2 != NULL) {
+				uint32_t j = cd->l2_group_index;
+				if (l2[j].size == 0) {
+					l2[j] = cd->l2;
+					l2[j].processor_start = pi;
+					l2[j].processor_count = 0;
+				}
+				if (pi < l2[j].processor_start) {
+					l2[j].processor_start = pi;
+				}
+				l2[j].processor_count++;
+				processors[pi].cache.l2 = &l2[j];
+			}
+			if (cd->l3.size != 0 && l3 != NULL) {
+				uint32_t j = cd->l3_group_index;
+				if (l3[j].size == 0) {
+					l3[j] = cd->l3;
+					l3[j].processor_start = pi;
+					l3[j].processor_count = 0;
+				}
+				if (pi < l3[j].processor_start) {
+					l3[j].processor_start = pi;
+				}
+				l3[j].processor_count++;
+				processors[pi].cache.l3 = &l3[j];
+			}
+		}
+
 		linux_cpu_to_processor_map[linux_id] = &processors[valid_processors_index - 1];
 		linux_cpu_to_core_map[linux_id] = &cores[valid_cores_index - 1];
 		linux_cpu_to_uarch_index_map[linux_id] = valid_uarchs_index - 1;
@@ -587,6 +793,15 @@ void cpuinfo_riscv_linux_init(void) {
 	cpuinfo_packages_count = valid_packages_count;
 	cpuinfo_uarchs = uarchs;
 	cpuinfo_uarchs_count = valid_uarchs_count;
+	cpuinfo_cache[cpuinfo_cache_level_1i] = l1i;
+	cpuinfo_cache[cpuinfo_cache_level_1d] = l1d;
+	cpuinfo_cache[cpuinfo_cache_level_2] = l2;
+	cpuinfo_cache[cpuinfo_cache_level_3] = l3;
+	cpuinfo_cache_count[cpuinfo_cache_level_1i] = l1i_count;
+	cpuinfo_cache_count[cpuinfo_cache_level_1d] = l1d_count;
+	cpuinfo_cache_count[cpuinfo_cache_level_2] = l2_count;
+	cpuinfo_cache_count[cpuinfo_cache_level_3] = l3_count;
+	cpuinfo_max_cache_size = cpuinfo_compute_max_cache_size(&processors[0]);
 
 	cpuinfo_linux_cpu_max = max_processor_id;
 	cpuinfo_linux_cpu_to_processor_map = linux_cpu_to_processor_map;
@@ -604,6 +819,7 @@ void cpuinfo_riscv_linux_init(void) {
 	clusters = NULL;
 	packages = NULL;
 	uarchs = NULL;
+	l1i = l1d = l2 = l3 = NULL;
 	linux_cpu_to_processor_map = NULL;
 	linux_cpu_to_core_map = NULL;
 	linux_cpu_to_uarch_index_map = NULL;
@@ -614,6 +830,15 @@ cleanup:
 	free(clusters);
 	free(packages);
 	free(uarchs);
+	free(l1i);
+	free(l1d);
+	free(l2);
+	free(l3);
+	free(cpu_caches);
+	free(l2_group_min_cpus);
+	free(l2_group_cpu_counts);
+	free(l3_group_min_cpus);
+	free(l3_group_cpu_counts);
 	free(linux_cpu_to_processor_map);
 	free(linux_cpu_to_core_map);
 	free(linux_cpu_to_uarch_index_map);
@@ -639,6 +864,13 @@ void cpuinfo_riscv_linux_deinit(void) {
 	free(cpuinfo_uarchs);
 	cpuinfo_uarchs = NULL;
 	cpuinfo_uarchs_count = 0;
+
+	for (int lvl = 0; lvl < cpuinfo_cache_level_max; ++lvl) {
+		free(cpuinfo_cache[lvl]);
+		cpuinfo_cache[lvl] = NULL;
+		cpuinfo_cache_count[lvl] = 0;
+	}
+	cpuinfo_max_cache_size = 0;
 
 	free(cpuinfo_linux_cpu_to_processor_map);
 	cpuinfo_linux_cpu_to_processor_map = NULL;

--- a/src/riscv/linux/init.c
+++ b/src/riscv/linux/init.c
@@ -222,6 +222,18 @@ static bool package_cpus_parser(
 	return true;
 }
 
+struct riscv_cpu_cache_data {
+	struct cpuinfo_cache l1i;
+	struct cpuinfo_cache l1d;
+	struct cpuinfo_cache l2;
+	struct cpuinfo_cache l3;
+	struct cpuinfo_riscv_cache_sharing_info l2_sharing;
+	struct cpuinfo_riscv_cache_sharing_info l3_sharing;
+	uint32_t l2_group_index;
+	uint32_t l3_group_index;
+	bool has_caches;
+};
+
 /* Initialization for the RISC-V Linux system. */
 void cpuinfo_riscv_linux_init(void) {
 	struct cpuinfo_riscv_linux_processor* riscv_linux_processors = NULL;
@@ -230,6 +242,15 @@ void cpuinfo_riscv_linux_init(void) {
 	struct cpuinfo_cluster* clusters = NULL;
 	struct cpuinfo_core* cores = NULL;
 	struct cpuinfo_uarch_info* uarchs = NULL;
+	struct cpuinfo_cache* l1i = NULL;
+	struct cpuinfo_cache* l1d = NULL;
+	struct cpuinfo_cache* l2 = NULL;
+	struct cpuinfo_cache* l3 = NULL;
+	struct riscv_cpu_cache_data* cpu_caches = NULL;
+	uint32_t* l2_group_min_cpus = NULL;
+	uint32_t* l2_group_cpu_counts = NULL;
+	uint32_t* l3_group_min_cpus = NULL;
+	uint32_t* l3_group_cpu_counts = NULL;
 	const struct cpuinfo_processor** linux_cpu_to_processor_map = NULL;
 	const struct cpuinfo_core** linux_cpu_to_core_map = NULL;
 	uint32_t* linux_cpu_to_uarch_index_map = NULL;
@@ -374,6 +395,37 @@ void cpuinfo_riscv_linux_init(void) {
 	/* Populate ISA structure with hwcap information. */
 	cpuinfo_riscv_linux_decode_isa_from_hwcap(&cpuinfo_isa);
 
+	/*
+	 * Parse sysfs cache topology before qsort reorders the processor
+	 * array. At this point, array index == linux_id.
+	 */
+	cpu_caches = calloc(max_processor_id, sizeof(struct riscv_cpu_cache_data));
+	if (cpu_caches == NULL) {
+		cpuinfo_log_error("failed to allocate cpu cache data");
+		goto cleanup;
+	}
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		if (cpuinfo_riscv_linux_parse_cache_from_sysfs(
+				processor,
+				&cpu_caches[processor].l1i,
+				&cpu_caches[processor].l1d,
+				&cpu_caches[processor].l2,
+				&cpu_caches[processor].l3)) {
+			cpu_caches[processor].has_caches = true;
+		}
+		if (cpu_caches[processor].l2.size != 0) {
+			cpuinfo_riscv_linux_get_cache_sharing(
+				processor, 2, &cpu_caches[processor].l2_sharing);
+		}
+		if (cpu_caches[processor].l3.size != 0) {
+			cpuinfo_riscv_linux_get_cache_sharing(
+				processor, 3, &cpu_caches[processor].l3_sharing);
+		}
+	}
+
 	/**
 	 * To efficiently compute the number of unique micro-architectures
 	 * present on the system, sort the processor list by micro-architecture
@@ -504,12 +556,119 @@ void cpuinfo_riscv_linux_init(void) {
 		goto cleanup;
 	}
 
+	/*
+	 * Count cache entries from pre-parsed data. L1 caches are per-
+	 * processor; L2/L3 are deduplicated by shared_cpu_list min_cpu.
+	 */
+	uint32_t l1i_count = 0;
+	uint32_t l1d_count = 0;
+	uint32_t l2_count = 0;
+	uint32_t l3_count = 0;
+	bool has_caches = false;
+
+	l2_group_min_cpus = calloc(valid_processors_count, sizeof(uint32_t));
+	l2_group_cpu_counts = calloc(valid_processors_count, sizeof(uint32_t));
+	l3_group_min_cpus = calloc(valid_processors_count, sizeof(uint32_t));
+	l3_group_cpu_counts = calloc(valid_processors_count, sizeof(uint32_t));
+	if (l2_group_min_cpus == NULL || l2_group_cpu_counts == NULL ||
+	    l3_group_min_cpus == NULL || l3_group_cpu_counts == NULL) {
+		cpuinfo_log_error("failed to allocate cache group arrays");
+		goto cleanup;
+	}
+
+	for (size_t processor = 0; processor < max_processor_id; processor++) {
+		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
+			continue;
+		}
+		uint32_t linux_id = riscv_linux_processors[processor].processor.linux_id;
+		if (cpu_caches[linux_id].has_caches) {
+			has_caches = true;
+		}
+		if (cpu_caches[linux_id].l1i.size != 0) {
+			l1i_count++;
+		}
+		if (cpu_caches[linux_id].l1d.size != 0) {
+			l1d_count++;
+		}
+		if (cpu_caches[linux_id].l2.size != 0) {
+			uint32_t min_cpu = cpu_caches[linux_id].l2_sharing.min_cpu;
+			uint32_t cpu_count = cpu_caches[linux_id].l2_sharing.cpu_count;
+			bool seen = false;
+			for (uint32_t j = 0; j < l2_count; j++) {
+				if (l2_group_min_cpus[j] == min_cpu &&
+				    l2_group_cpu_counts[j] == cpu_count) {
+					cpu_caches[linux_id].l2_group_index = j;
+					seen = true;
+					break;
+				}
+			}
+			if (!seen) {
+				l2_group_min_cpus[l2_count] = min_cpu;
+				l2_group_cpu_counts[l2_count] = cpu_count;
+				cpu_caches[linux_id].l2_group_index = l2_count;
+				l2_count++;
+			}
+		}
+		if (cpu_caches[linux_id].l3.size != 0) {
+			uint32_t min_cpu = cpu_caches[linux_id].l3_sharing.min_cpu;
+			uint32_t cpu_count = cpu_caches[linux_id].l3_sharing.cpu_count;
+			bool seen = false;
+			for (uint32_t j = 0; j < l3_count; j++) {
+				if (l3_group_min_cpus[j] == min_cpu &&
+				    l3_group_cpu_counts[j] == cpu_count) {
+					cpu_caches[linux_id].l3_group_index = j;
+					seen = true;
+					break;
+				}
+			}
+			if (!seen) {
+				l3_group_min_cpus[l3_count] = min_cpu;
+				l3_group_cpu_counts[l3_count] = cpu_count;
+				cpu_caches[linux_id].l3_group_index = l3_count;
+				l3_count++;
+			}
+		}
+	}
+
+	if (has_caches) {
+		if (l1i_count != 0) {
+			l1i = calloc(l1i_count, sizeof(struct cpuinfo_cache));
+			if (l1i == NULL) {
+				cpuinfo_log_error("failed to allocate L1I cache array");
+				goto cleanup;
+			}
+		}
+		if (l1d_count != 0) {
+			l1d = calloc(l1d_count, sizeof(struct cpuinfo_cache));
+			if (l1d == NULL) {
+				cpuinfo_log_error("failed to allocate L1D cache array");
+				goto cleanup;
+			}
+		}
+		if (l2_count != 0) {
+			l2 = calloc(l2_count, sizeof(struct cpuinfo_cache));
+			if (l2 == NULL) {
+				cpuinfo_log_error("failed to allocate L2 cache array");
+				goto cleanup;
+			}
+		}
+		if (l3_count != 0) {
+			l3 = calloc(l3_count, sizeof(struct cpuinfo_cache));
+			if (l3 == NULL) {
+				cpuinfo_log_error("failed to allocate L3 cache array");
+				goto cleanup;
+			}
+		}
+	}
+
 	/* Transfer contents of processor list to ABI structures. */
 	size_t valid_processors_index = 0;
 	size_t valid_cores_index = 0;
 	size_t valid_clusters_index = 0;
 	size_t valid_packages_index = 0;
 	size_t valid_uarchs_index = 0;
+	uint32_t l1i_index = 0;
+	uint32_t l1d_index = 0;
 	last_uarch = cpuinfo_uarch_unknown;
 	for (size_t processor = 0; processor < max_processor_id; processor++) {
 		if (!bitmask_all(riscv_linux_processors[processor].flags, CPUINFO_LINUX_FLAG_VALID)) {
@@ -571,6 +730,53 @@ void cpuinfo_riscv_linux_init(void) {
 
 		clusters[valid_clusters_index - 1].package = &packages[valid_packages_index - 1];
 
+		/* Populate cache from pre-parsed sysfs data. */
+		if (has_caches) {
+			const uint32_t pi = valid_processors_index - 1;
+			struct riscv_cpu_cache_data* cd = &cpu_caches[linux_id];
+
+			if (cd->l1i.size != 0 && l1i != NULL) {
+				l1i[l1i_index] = cd->l1i;
+				l1i[l1i_index].processor_start = pi;
+				l1i[l1i_index].processor_count = 1;
+				processors[pi].cache.l1i = &l1i[l1i_index];
+				l1i_index++;
+			}
+			if (cd->l1d.size != 0 && l1d != NULL) {
+				l1d[l1d_index] = cd->l1d;
+				l1d[l1d_index].processor_start = pi;
+				l1d[l1d_index].processor_count = 1;
+				processors[pi].cache.l1d = &l1d[l1d_index];
+				l1d_index++;
+			}
+			if (cd->l2.size != 0 && l2 != NULL) {
+				uint32_t j = cd->l2_group_index;
+				if (l2[j].size == 0) {
+					l2[j] = cd->l2;
+					l2[j].processor_start = pi;
+					l2[j].processor_count = 0;
+				}
+				if (pi < l2[j].processor_start) {
+					l2[j].processor_start = pi;
+				}
+				l2[j].processor_count++;
+				processors[pi].cache.l2 = &l2[j];
+			}
+			if (cd->l3.size != 0 && l3 != NULL) {
+				uint32_t j = cd->l3_group_index;
+				if (l3[j].size == 0) {
+					l3[j] = cd->l3;
+					l3[j].processor_start = pi;
+					l3[j].processor_count = 0;
+				}
+				if (pi < l3[j].processor_start) {
+					l3[j].processor_start = pi;
+				}
+				l3[j].processor_count++;
+				processors[pi].cache.l3 = &l3[j];
+			}
+		}
+
 		linux_cpu_to_processor_map[linux_id] = &processors[valid_processors_index - 1];
 		linux_cpu_to_core_map[linux_id] = &cores[valid_cores_index - 1];
 		linux_cpu_to_uarch_index_map[linux_id] = valid_uarchs_index - 1;
@@ -587,6 +793,15 @@ void cpuinfo_riscv_linux_init(void) {
 	cpuinfo_packages_count = valid_packages_count;
 	cpuinfo_uarchs = uarchs;
 	cpuinfo_uarchs_count = valid_uarchs_count;
+	cpuinfo_cache[cpuinfo_cache_level_1i] = l1i;
+	cpuinfo_cache[cpuinfo_cache_level_1d] = l1d;
+	cpuinfo_cache[cpuinfo_cache_level_2] = l2;
+	cpuinfo_cache[cpuinfo_cache_level_3] = l3;
+	cpuinfo_cache_count[cpuinfo_cache_level_1i] = l1i_count;
+	cpuinfo_cache_count[cpuinfo_cache_level_1d] = l1d_count;
+	cpuinfo_cache_count[cpuinfo_cache_level_2] = l2_count;
+	cpuinfo_cache_count[cpuinfo_cache_level_3] = l3_count;
+	cpuinfo_max_cache_size = cpuinfo_compute_max_cache_size(&processors[0]);
 
 	cpuinfo_linux_cpu_max = max_processor_id;
 	cpuinfo_linux_cpu_to_processor_map = linux_cpu_to_processor_map;
@@ -604,6 +819,7 @@ void cpuinfo_riscv_linux_init(void) {
 	clusters = NULL;
 	packages = NULL;
 	uarchs = NULL;
+	l1i = l1d = l2 = l3 = NULL;
 	linux_cpu_to_processor_map = NULL;
 	linux_cpu_to_core_map = NULL;
 	linux_cpu_to_uarch_index_map = NULL;
@@ -614,6 +830,15 @@ cleanup:
 	free(clusters);
 	free(packages);
 	free(uarchs);
+	free(l1i);
+	free(l1d);
+	free(l2);
+	free(l3);
+	free(cpu_caches);
+	free(l2_group_min_cpus);
+	free(l2_group_cpu_counts);
+	free(l3_group_min_cpus);
+	free(l3_group_cpu_counts);
 	free(linux_cpu_to_processor_map);
 	free(linux_cpu_to_core_map);
 	free(linux_cpu_to_uarch_index_map);

--- a/src/riscv/linux/riscv-hw.c
+++ b/src/riscv/linux/riscv-hw.c
@@ -44,39 +44,39 @@ struct riscv_hwprobe {
 #define RISCV_HWPROBE_KEY_MARCHID 1
 #define RISCV_HWPROBE_KEY_MIMPID 2
 #define RISCV_HWPROBE_KEY_BASE_BEHAVIOR 3
-#define RISCV_HWPROBE_BASE_BEHAVIOR_IMA (1 << 0)
+#define RISCV_HWPROBE_BASE_BEHAVIOR_IMA (1ULL << 0)
 #define RISCV_HWPROBE_KEY_IMA_EXT_0 4
-#define RISCV_HWPROBE_IMA_FD (1 << 0)
-#define RISCV_HWPROBE_IMA_C (1 << 1)
-#define RISCV_HWPROBE_IMA_V (1 << 2)
-#define RISCV_HWPROBE_EXT_ZBA (1 << 3)
-#define RISCV_HWPROBE_EXT_ZBB (1 << 4)
-#define RISCV_HWPROBE_EXT_ZBS (1 << 5)
-#define RISCV_HWPROBE_EXT_ZICBOZ (1 << 6)
-#define RISCV_HWPROBE_EXT_ZBC (1 << 7)
-#define RISCV_HWPROBE_EXT_ZBKB (1 << 8)
-#define RISCV_HWPROBE_EXT_ZBKC (1 << 9)
-#define RISCV_HWPROBE_EXT_ZBKX (1 << 10)
-#define RISCV_HWPROBE_EXT_ZKND (1 << 11)
-#define RISCV_HWPROBE_EXT_ZKNE (1 << 12)
-#define RISCV_HWPROBE_EXT_ZKNH (1 << 13)
-#define RISCV_HWPROBE_EXT_ZKSED (1 << 14)
-#define RISCV_HWPROBE_EXT_ZKSH (1 << 15)
-#define RISCV_HWPROBE_EXT_ZKT (1 << 16)
-#define RISCV_HWPROBE_EXT_ZVBB (1 << 17)
-#define RISCV_HWPROBE_EXT_ZVBC (1 << 18)
-#define RISCV_HWPROBE_EXT_ZVKB (1 << 19)
-#define RISCV_HWPROBE_EXT_ZVKG (1 << 20)
-#define RISCV_HWPROBE_EXT_ZVKNED (1 << 21)
-#define RISCV_HWPROBE_EXT_ZVKNHA (1 << 22)
-#define RISCV_HWPROBE_EXT_ZVKNHB (1 << 23)
-#define RISCV_HWPROBE_EXT_ZVKSED (1 << 24)
-#define RISCV_HWPROBE_EXT_ZVKSH (1 << 25)
-#define RISCV_HWPROBE_EXT_ZVKT (1 << 26)
-#define RISCV_HWPROBE_EXT_ZFH (1 << 27)
-#define RISCV_HWPROBE_EXT_ZFHMIN (1 << 28)
-#define RISCV_HWPROBE_EXT_ZIHINTNTL (1 << 29)
-#define RISCV_HWPROBE_EXT_ZVFH (1 << 30)
+#define RISCV_HWPROBE_IMA_FD (1ULL << 0)
+#define RISCV_HWPROBE_IMA_C (1ULL << 1)
+#define RISCV_HWPROBE_IMA_V (1ULL << 2)
+#define RISCV_HWPROBE_EXT_ZBA (1ULL << 3)
+#define RISCV_HWPROBE_EXT_ZBB (1ULL << 4)
+#define RISCV_HWPROBE_EXT_ZBS (1ULL << 5)
+#define RISCV_HWPROBE_EXT_ZICBOZ (1ULL << 6)
+#define RISCV_HWPROBE_EXT_ZBC (1ULL << 7)
+#define RISCV_HWPROBE_EXT_ZBKB (1ULL << 8)
+#define RISCV_HWPROBE_EXT_ZBKC (1ULL << 9)
+#define RISCV_HWPROBE_EXT_ZBKX (1ULL << 10)
+#define RISCV_HWPROBE_EXT_ZKND (1ULL << 11)
+#define RISCV_HWPROBE_EXT_ZKNE (1ULL << 12)
+#define RISCV_HWPROBE_EXT_ZKNH (1ULL << 13)
+#define RISCV_HWPROBE_EXT_ZKSED (1ULL << 14)
+#define RISCV_HWPROBE_EXT_ZKSH (1ULL << 15)
+#define RISCV_HWPROBE_EXT_ZKT (1ULL << 16)
+#define RISCV_HWPROBE_EXT_ZVBB (1ULL << 17)
+#define RISCV_HWPROBE_EXT_ZVBC (1ULL << 18)
+#define RISCV_HWPROBE_EXT_ZVKB (1ULL << 19)
+#define RISCV_HWPROBE_EXT_ZVKG (1ULL << 20)
+#define RISCV_HWPROBE_EXT_ZVKNED (1ULL << 21)
+#define RISCV_HWPROBE_EXT_ZVKNHA (1ULL << 22)
+#define RISCV_HWPROBE_EXT_ZVKNHB (1ULL << 23)
+#define RISCV_HWPROBE_EXT_ZVKSED (1ULL << 24)
+#define RISCV_HWPROBE_EXT_ZVKSH (1ULL << 25)
+#define RISCV_HWPROBE_EXT_ZVKT (1ULL << 26)
+#define RISCV_HWPROBE_EXT_ZFH (1ULL << 27)
+#define RISCV_HWPROBE_EXT_ZFHMIN (1ULL << 28)
+#define RISCV_HWPROBE_EXT_ZIHINTNTL (1ULL << 29)
+#define RISCV_HWPROBE_EXT_ZVFH (1ULL << 30)
 #define RISCV_HWPROBE_KEY_CPUPERF_0 5
 #define RISCV_HWPROBE_MISALIGNED_UNKNOWN (0 << 0)
 #define RISCV_HWPROBE_MISALIGNED_EMULATED (1 << 0)
@@ -153,9 +153,9 @@ void cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
 	 * The syscall may not have populated all requested keys, loop through
 	 * the list and store the values that were discovered.
 	 */
-	uint32_t vendor_id = 0;
-	uint32_t arch_id = 0;
-	uint32_t imp_id = 0;
+	uint64_t vendor_id = 0;
+	uint64_t arch_id = 0;
+	uint64_t imp_id = 0;
 	uint64_t ima_ext_0 = 0;
 	for (size_t pair = 0; pair < pairs_count; pair++) {
 		switch (pairs[pair].key) {
@@ -183,8 +183,86 @@ void cpuinfo_riscv_linux_decode_vendor_uarch_from_hwprobe(
 		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZFH) {
 			isa->zfh = true;
 		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZFHMIN) {
+			isa->zfhmin = true;
+		}
 		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVFH) {
 			isa->zvfh = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBA) {
+			isa->zba = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBB) {
+			isa->zbb = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBS) {
+			isa->zbs = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBC) {
+			isa->zbc = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBKB) {
+			isa->zbkb = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBKC) {
+			isa->zbkc = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZBKX) {
+			isa->zbkx = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZKND) {
+			isa->zknd = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZKNE) {
+			isa->zkne = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZKNH) {
+			isa->zknh = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZKSED) {
+			isa->zksed = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZKSH) {
+			isa->zksh = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZKT) {
+			isa->zkt = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVBB) {
+			isa->zvbb = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVBC) {
+			isa->zvbc = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKB) {
+			isa->zvkb = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKG) {
+			isa->zvkg = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKNED) {
+			isa->zvkned = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKNHA) {
+			isa->zvknha = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKNHB) {
+			isa->zvknhb = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKSED) {
+			isa->zvksed = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKSH) {
+			isa->zvksh = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZVKT) {
+			isa->zvkt = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZICBOZ) {
+			isa->zicboz = true;
+		}
+		if (ima_ext_0 & RISCV_HWPROBE_EXT_ZIHINTNTL) {
+			isa->zihintntl = true;
 		}
 	}
 

--- a/src/riscv/uarch.c
+++ b/src/riscv/uarch.c
@@ -3,25 +3,79 @@
 #include <cpuinfo/log.h>
 #include <riscv/api.h>
 
+/*
+ * SiFive 7-series marchid values.
+ * The high bit (63) indicates a commercial implementation per RISC-V spec.
+ * Some revisions of the U74/FU740 report marchid=0x1 instead.
+ */
+#define SIFIVE_MARCHID_7_SERIES UINT64_C(0x8000000000000007)
+#define SIFIVE_MARCHID_7_SERIES_ALT UINT64_C(0x1)
+
+/*
+ * T-Head C908 marchid. Earlier T-Head c9xx cores (C906, C910, C920)
+ * report marchid=0 and mimpid=0, so they cannot be distinguished
+ * individually and are grouped as cpuinfo_uarch_thead_c9xx.
+ */
+#define THEAD_MARCHID_C908 UINT64_C(0x8d143000)
+
+/* SpacemiT X60 (Veyron V1) marchid. */
+#define SPACEMIT_MARCHID_X60 UINT64_C(0x8000000000010000)
+
 void cpuinfo_riscv_decode_vendor_uarch(
-	uint32_t vendor_id,
-	uint32_t arch_id,
-	uint32_t imp_id,
+	uint64_t vendor_id,
+	uint64_t arch_id,
+	uint64_t imp_id,
 	enum cpuinfo_vendor vendor[restrict static 1],
 	enum cpuinfo_uarch uarch[restrict static 1]) {
-	/* The vendor ID is sufficient to determine the cpuinfo_vendor. */
 	switch (vendor_id) {
 		case cpuinfo_riscv_chipset_vendor_sifive:
 			*vendor = cpuinfo_vendor_sifive;
+			switch (arch_id) {
+				case SIFIVE_MARCHID_7_SERIES:
+				case SIFIVE_MARCHID_7_SERIES_ALT:
+					*uarch = cpuinfo_uarch_sifive_7_series;
+					break;
+				default:
+					*uarch = cpuinfo_uarch_unknown;
+					break;
+			}
+			break;
+		case cpuinfo_riscv_chipset_vendor_thead:
+			*vendor = cpuinfo_vendor_thead;
+			switch (arch_id) {
+				case THEAD_MARCHID_C908:
+					*uarch = cpuinfo_uarch_thead_c908;
+					break;
+				case 0:
+					/*
+					 * T-Head c9xx cores (C906, C910, C920) all
+					 * report marchid=0. They can only be
+					 * differentiated by ISA extensions.
+					 */
+					*uarch = cpuinfo_uarch_thead_c9xx;
+					break;
+				default:
+					*uarch = cpuinfo_uarch_unknown;
+					break;
+			}
+			break;
+		case cpuinfo_riscv_chipset_vendor_spacemit:
+			*vendor = cpuinfo_vendor_spacemit;
+			switch (arch_id) {
+				case SPACEMIT_MARCHID_X60:
+					*uarch = cpuinfo_uarch_spacemit_x60;
+					break;
+				default:
+					*uarch = cpuinfo_uarch_unknown;
+					break;
+			}
 			break;
 		default:
 			*vendor = cpuinfo_vendor_unknown;
-			cpuinfo_log_warning("unknown vendor ID: %" PRIu32, vendor_id);
+			*uarch = cpuinfo_uarch_unknown;
+			if (vendor_id != 0) {
+				cpuinfo_log_warning("unknown vendor ID: %" PRIu64, vendor_id);
+			}
 			break;
 	}
-	/**
-	 * TODO: Add support for parsing chipset architecture and implementation
-	 * IDs here, when a chipset of interest comes along.
-	 */
-	*uarch = cpuinfo_uarch_unknown;
 }

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -200,8 +200,38 @@ int main(int argc, char** argv) {
 	printf("\tSingle-Precision Floating-Point: %s\n", cpuinfo_has_riscv_f() ? "yes" : "no");
 	printf("\tDouble-Precision Floating-Point: %s\n", cpuinfo_has_riscv_d() ? "yes" : "no");
 	printf("\tHalf-Precision Floating-Point: %s\n", cpuinfo_has_riscv_zfh() ? "yes" : "no");
+	printf("\tHalf-Precision Floating-Point Minimum: %s\n", cpuinfo_has_riscv_zfhmin() ? "yes" : "no");
 	printf("\tCompressed: %s\n", cpuinfo_has_riscv_c() ? "yes" : "no");
 	printf("\tVector: %s\n", cpuinfo_has_riscv_v() ? "yes" : "no");
 	printf("\tVector Half-Precision Floating-Point: %s\n", cpuinfo_has_riscv_zvfh() ? "yes" : "no");
+	printf("Bit Manipulation:\n");
+	printf("\tZba (Address Generation): %s\n", cpuinfo_has_riscv_zba() ? "yes" : "no");
+	printf("\tZbb (Basic Bit Manipulation): %s\n", cpuinfo_has_riscv_zbb() ? "yes" : "no");
+	printf("\tZbs (Single-Bit): %s\n", cpuinfo_has_riscv_zbs() ? "yes" : "no");
+	printf("\tZbc (Carry-less Multiply): %s\n", cpuinfo_has_riscv_zbc() ? "yes" : "no");
+	printf("Scalar Crypto:\n");
+	printf("\tZbkb (Bit Manipulation for Crypto): %s\n", cpuinfo_has_riscv_zbkb() ? "yes" : "no");
+	printf("\tZbkc (Carry-less Multiply for Crypto): %s\n", cpuinfo_has_riscv_zbkc() ? "yes" : "no");
+	printf("\tZbkx (Crossbar Permutation): %s\n", cpuinfo_has_riscv_zbkx() ? "yes" : "no");
+	printf("\tZknd (AES Decrypt): %s\n", cpuinfo_has_riscv_zknd() ? "yes" : "no");
+	printf("\tZkne (AES Encrypt): %s\n", cpuinfo_has_riscv_zkne() ? "yes" : "no");
+	printf("\tZknh (SHA-2): %s\n", cpuinfo_has_riscv_zknh() ? "yes" : "no");
+	printf("\tZksed (SM4): %s\n", cpuinfo_has_riscv_zksed() ? "yes" : "no");
+	printf("\tZksh (SM3): %s\n", cpuinfo_has_riscv_zksh() ? "yes" : "no");
+	printf("\tZkt (Data Independent Execution Latency): %s\n", cpuinfo_has_riscv_zkt() ? "yes" : "no");
+	printf("Vector Crypto:\n");
+	printf("\tZvbb (Vector Bit Manipulation): %s\n", cpuinfo_has_riscv_zvbb() ? "yes" : "no");
+	printf("\tZvbc (Vector Carry-less Multiply): %s\n", cpuinfo_has_riscv_zvbc() ? "yes" : "no");
+	printf("\tZvkb (Vector Crypto Bit Manipulation): %s\n", cpuinfo_has_riscv_zvkb() ? "yes" : "no");
+	printf("\tZvkg (Vector GCM/GMAC): %s\n", cpuinfo_has_riscv_zvkg() ? "yes" : "no");
+	printf("\tZvkned (Vector AES): %s\n", cpuinfo_has_riscv_zvkned() ? "yes" : "no");
+	printf("\tZvknha (Vector SHA-2 256): %s\n", cpuinfo_has_riscv_zvknha() ? "yes" : "no");
+	printf("\tZvknhb (Vector SHA-2 512): %s\n", cpuinfo_has_riscv_zvknhb() ? "yes" : "no");
+	printf("\tZvksed (Vector SM4): %s\n", cpuinfo_has_riscv_zvksed() ? "yes" : "no");
+	printf("\tZvksh (Vector SM3): %s\n", cpuinfo_has_riscv_zvksh() ? "yes" : "no");
+	printf("\tZvkt (Vector Data Independent Execution Latency): %s\n", cpuinfo_has_riscv_zvkt() ? "yes" : "no");
+	printf("Other:\n");
+	printf("\tZicboz (Cache Block Zero): %s\n", cpuinfo_has_riscv_zicboz() ? "yes" : "no");
+	printf("\tZihintntl (Non-Temporal Locality Hints): %s\n", cpuinfo_has_riscv_zihintntl() ? "yes" : "no");
 #endif
 }

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -204,8 +204,38 @@ int main(int argc, char** argv) {
 	printf("\tSingle-Precision Floating-Point: %s\n", cpuinfo_has_riscv_f() ? "yes" : "no");
 	printf("\tDouble-Precision Floating-Point: %s\n", cpuinfo_has_riscv_d() ? "yes" : "no");
 	printf("\tHalf-Precision Floating-Point: %s\n", cpuinfo_has_riscv_zfh() ? "yes" : "no");
+	printf("\tHalf-Precision Floating-Point Minimum: %s\n", cpuinfo_has_riscv_zfhmin() ? "yes" : "no");
 	printf("\tCompressed: %s\n", cpuinfo_has_riscv_c() ? "yes" : "no");
 	printf("\tVector: %s\n", cpuinfo_has_riscv_v() ? "yes" : "no");
 	printf("\tVector Half-Precision Floating-Point: %s\n", cpuinfo_has_riscv_zvfh() ? "yes" : "no");
+	printf("Bit Manipulation:\n");
+	printf("\tZba (Address Generation): %s\n", cpuinfo_has_riscv_zba() ? "yes" : "no");
+	printf("\tZbb (Basic Bit Manipulation): %s\n", cpuinfo_has_riscv_zbb() ? "yes" : "no");
+	printf("\tZbs (Single-Bit): %s\n", cpuinfo_has_riscv_zbs() ? "yes" : "no");
+	printf("\tZbc (Carry-less Multiply): %s\n", cpuinfo_has_riscv_zbc() ? "yes" : "no");
+	printf("Scalar Crypto:\n");
+	printf("\tZbkb (Bit Manipulation for Crypto): %s\n", cpuinfo_has_riscv_zbkb() ? "yes" : "no");
+	printf("\tZbkc (Carry-less Multiply for Crypto): %s\n", cpuinfo_has_riscv_zbkc() ? "yes" : "no");
+	printf("\tZbkx (Crossbar Permutation): %s\n", cpuinfo_has_riscv_zbkx() ? "yes" : "no");
+	printf("\tZknd (AES Decrypt): %s\n", cpuinfo_has_riscv_zknd() ? "yes" : "no");
+	printf("\tZkne (AES Encrypt): %s\n", cpuinfo_has_riscv_zkne() ? "yes" : "no");
+	printf("\tZknh (SHA-2): %s\n", cpuinfo_has_riscv_zknh() ? "yes" : "no");
+	printf("\tZksed (SM4): %s\n", cpuinfo_has_riscv_zksed() ? "yes" : "no");
+	printf("\tZksh (SM3): %s\n", cpuinfo_has_riscv_zksh() ? "yes" : "no");
+	printf("\tZkt (Data Independent Execution Latency): %s\n", cpuinfo_has_riscv_zkt() ? "yes" : "no");
+	printf("Vector Crypto:\n");
+	printf("\tZvbb (Vector Bit Manipulation): %s\n", cpuinfo_has_riscv_zvbb() ? "yes" : "no");
+	printf("\tZvbc (Vector Carry-less Multiply): %s\n", cpuinfo_has_riscv_zvbc() ? "yes" : "no");
+	printf("\tZvkb (Vector Crypto Bit Manipulation): %s\n", cpuinfo_has_riscv_zvkb() ? "yes" : "no");
+	printf("\tZvkg (Vector GCM/GMAC): %s\n", cpuinfo_has_riscv_zvkg() ? "yes" : "no");
+	printf("\tZvkned (Vector AES): %s\n", cpuinfo_has_riscv_zvkned() ? "yes" : "no");
+	printf("\tZvknha (Vector SHA-2 256): %s\n", cpuinfo_has_riscv_zvknha() ? "yes" : "no");
+	printf("\tZvknhb (Vector SHA-2 512): %s\n", cpuinfo_has_riscv_zvknhb() ? "yes" : "no");
+	printf("\tZvksed (Vector SM4): %s\n", cpuinfo_has_riscv_zvksed() ? "yes" : "no");
+	printf("\tZvksh (Vector SM3): %s\n", cpuinfo_has_riscv_zvksh() ? "yes" : "no");
+	printf("\tZvkt (Vector Data Independent Execution Latency): %s\n", cpuinfo_has_riscv_zvkt() ? "yes" : "no");
+	printf("Other:\n");
+	printf("\tZicboz (Cache Block Zero): %s\n", cpuinfo_has_riscv_zicboz() ? "yes" : "no");
+	printf("\tZihintntl (Non-Temporal Locality Hints): %s\n", cpuinfo_has_riscv_zihintntl() ? "yes" : "no");
 #endif
 }


### PR DESCRIPTION
PR #190 added a RISC-V initialization skeleton with 7 base ISA extensions (I/M/A/F/D/C/V), SiFive-only vendor detection, and a stub uarch decoder that always returned `unknown`. This PR completes that work.

**ISA extensions (28 new)**
The hwprobe syscall already queries `IMA_EXT_0` flags but only ZFH/ZVFH were wired to the public API. This exposes all remaining extensions: bit manipulation (Zba/Zbb/Zbs/Zbc), scalar crypto (Zbkb/Zbkc/Zbkx/Zknd/Zkne/Zknh/Zksed/Zksh/Zkt), vector crypto (Zvbb/Zvbc/Zvkb/Zvkg/Zvkned/Zvknha/Zvknhb/Zvksed/Zvksh/Zvkt), and others (Zicboz/Zihintntl/Zfhmin).

**Vendor and microarchitecture detection**
Adds T-Head (0x5b7) and SpacemiT (0x61f) vendor IDs. Implements the marchid-based uarch decode that #190 left as a TODO — SiFive 7-series, T-Head C9xx/C908, SpacemiT X60. Fixes `uint32_t` truncation of 64-bit marchid values.

**Cache topology**
Adds sysfs-based cache detection (`/sys/devices/system/cpu/cpuN/cache/indexM/`) for L1i/L1d/L2/L3 with shared cache deduplication. Gracefully returns no cache info when sysfs is absent.

## Test plan

- [x] Cross-compiled with `riscv64-linux-gnu-gcc` — zero errors/warnings
- [x] Native build on RISC-V QEMU system VM (Ubuntu 24.04, kernel 6.17, GCC 13.3) — zero errors/warnings
- [x] `cpu-info` — correctly detects 2 processors, 2 cores, 1 cluster
- [x] `isa-info` — all 30 extension accessors work (I/M/A/F/D/C = yes, advanced = no on QEMU virt)
- [x] `cache-info` — graceful degradation (0 bytes) when sysfs cache absent (QEMU virt)
- [x] x86 native build — no regressions, all three tools produce correct output
- [ ] Real hardware validation (SiFive VisionFive 2, BananaPi BPI-F3, etc.) — vendor/uarch and cache paths need real board testing

Closes #124