### PR TITLE
Fix crashing: arm/linux deref NULL in special situation.

### DIFF
--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -806,22 +806,19 @@ void cpuinfo_arm_linux_init(void) {
 			 * between all cores
 			 */
 			shared_l3 = false;
-			if (temp_l2.size != 0) {
-				/* Check if L2 is per-core using sysfs */
-				uint32_t sysfs_l2_size = cpuinfo_linux_read_sysfs_cache_size(
-					arm_linux_processors[i].system_processor_id, 2);
-				bool l2_is_per_core = (sysfs_l2_size > 0) &&
-					cpuinfo_linux_is_l2_per_core(arm_linux_processors[i].system_processor_id);
-
-				if (l2_is_per_core) {
-					/* L2 is private to each core */
+			/* Check if L2 is per-core using sysfs */
+			uint32_t sysfs_l2_size =
+				cpuinfo_linux_read_sysfs_cache_size(arm_linux_processors[i].system_processor_id, 2);
+			bool l2_is_per_core = (sysfs_l2_size > 0) &&
+				cpuinfo_linux_is_l2_per_core(arm_linux_processors[i].system_processor_id);
+			if (l2_is_per_core) {
+				/* L2 is private to each core */
+				l2_count += 1;
+			} else if (temp_l2.size != 0) {
+				/* Assume L2 is shared by cores in the same cluster */
+				if (arm_linux_processors[i].package_leader_id ==
+				    arm_linux_processors[i].system_processor_id) {
 					l2_count += 1;
-				} else {
-					/* Assume L2 is shared by cores in the same cluster */
-					if (arm_linux_processors[i].package_leader_id ==
-					    arm_linux_processors[i].system_processor_id) {
-						l2_count += 1;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
## arm/linux: align L2 per-core counting with the fill loop to fix NULL deref

### Problem

`import torch` crash in my cloud docker, with following stack:
```
[2026/06/24 15:54:46.689 GMT+08:00] Type "apropos word" to search for commands related to "word"...
[2026/06/24 15:54:46.689 GMT+08:00] Reading symbols from python3.10...
[2026/06/24 15:54:46.689 GMT+08:00] (No debugging symbols found in python3.10)
[2026/06/24 15:54:46.689 GMT+08:00] Starting program: /usr/local/bin/python3.10 -c import\ torch\;\ print\(torch.__version__\)
[2026/06/24 15:54:46.689 GMT+08:00] [Thread debugging using libthread_db enabled]
[2026/06/24 15:54:46.689 GMT+08:00] Using host libthread_db library "/lib64/libthread_db.so.1".
[2026/06/24 15:54:47.633 GMT+08:00] 
[2026/06/24 15:54:47.633 GMT+08:00] Program received signal SIGSEGV, Segmentation fault.
[2026/06/24 15:54:47.633 GMT+08:00] 0x0000fffff7f90dd8 in cpuinfo_arm_linux_init () from /tmp/torch_npu_cpuinfo_upstream.so
[2026/06/24 15:54:47.633 GMT+08:00] #0  0x0000fffff7f90dd8 in cpuinfo_arm_linux_init ()
[2026/06/24 15:54:47.633 GMT+08:00]    from /tmp/torch_npu_cpuinfo_upstream.so
[2026/06/24 15:54:47.633 GMT+08:00] #1  0x0000fffff7f1e3cc in __pthread_once_slow () from /lib64/libpthread.so.0
[2026/06/24 15:54:47.633 GMT+08:00] #2  0x0000fffff7f8ddac in cpuinfo_initialize ()
[2026/06/24 15:54:47.633 GMT+08:00]    from /tmp/torch_npu_cpuinfo_upstream.so
[2026/06/24 15:54:47.633 GMT+08:00] #3  0x0000ffffea97b250 in c10::TaskThreadPoolBase::defaultNumThreads() ()
[2026/06/24 15:54:47.633 GMT+08:00]    from /opt/_internal/cpython-3.10.20/lib/python3.10/site-packages/torch/lib/libc10.so
[2026/06/24 15:54:47.633 GMT+08:00] #4  0x0000ffffebb520c8 in at::intraop_default_num_threads() ()
[2026/06/24 15:54:47.633 GMT+08:00]    from /opt/_internal/cpython-3.10.20/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
[2026/06/24 15:54:47.633 GMT+08:00] #5  0x0000ffffebb53874 in at::init_num_threads() ()
[2026/06/24 15:54:47.633 GMT+08:00]    from /opt/_internal/cpython-3.10.20/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so
[2026/06/24 15:54:47.633 GMT+08:00] #6  0x0000fffff60b0200 in initModule ()
[2026/06/24 15:54:47.633 GMT+08:00]    from /opt/_internal/cpython-3.10.20/lib/python3.10/site-packages/torch/lib/libtorch_python.so
[2026/06/24 15:54:47.633 GMT+08:00] #7  0x00000000004e50d4 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #8  0x00000000004e21b8 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #9  0x00000000005a7b90 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #10 0x00000000004bc1a4 in _PyEval_EvalFrameDefault ()
[2026/06/24 15:54:47.633 GMT+08:00] #11 0x00000000004c2f00 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #12 0x00000000004c1a84 in _PyEval_EvalFrameDefault ()
[2026/06/24 15:54:47.633 GMT+08:00] #13 0x00000000004c2f00 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #14 0x00000000004c0468 in _PyEval_EvalFrameDefault ()
[2026/06/24 15:54:47.633 GMT+08:00] #15 0x00000000004c2f00 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #16 0x00000000004bfc4c in _PyEval_EvalFrameDefault ()
[2026/06/24 15:54:47.633 GMT+08:00] #17 0x00000000004c2f00 in ?? ()
[2026/06/24 15:54:47.633 GMT+08:00] #18 0x00000000004bfc4c in _PyEval_EvalFrameDefault ()
[2026/06/24 15:54:47.633 GMT+08:00] #19 0x00000000004c2f00 in ?? ()
[2026/06/24 15:54:47.634 GMT+08:00] #20 0x00000000004bfc4c in _PyEval_EvalFrameDefault ()
```

### Root Cause

After analyse, I find it crash as this line: https://github.com/pytorch/cpuinfo/blob/main/src/arm/linux/init.c#L935

`cpuinfo_arm_linux_init` processes the L2 cache array in two passes: a **counting pass** that computes `l2_count` and `calloc`s the `l2[]` array, and a **filling pass** that writes the entries. Both passes must agree on whether a given CPU contributes an L2 entry; otherwise the filling pass writes past the allocation or dereferences a NULL pointer.

The two passes used **inconsistent conditions** for the per-core L2 case:

- The **filling pass** reads sysfs **unconditionally** to decide `l2_is_per_core`, and treats a per-core L2 as a contributed entry regardless of what `cpuinfo_arm_decode_cache` returned:

  ```c
  bool l2_is_per_core = (sysfs_l2_size > 0) && cpuinfo_linux_is_l2_per_core(...);
  if (temp_l3.size != 0 || l2_is_per_core) { ... l2[++l2_index] = ...; }
  ```

- The **counting pass** gated the very same sysfs/per-core check behind `if (temp_l2.size != 0)`:

  ```c
  if (temp_l2.size != 0) {            // extra precondition not present in the fill pass
      bool l2_is_per_core = ...;
      if (l2_is_per_core) l2_count += 1;
      ...
  }
  ```

In the special case where `cpuinfo_arm_decode_cache` returns `temp_l2.size == 0` (its default for an unrecognised microarchitecture when uarch==0, arch_version==0, in https://github.com/pytorch/cpuinfo/blob/main/src/arm/cache.c#L1619). maybe due to some special virtualization. 
But sysfs reports a real per-core L2, the counting pass skips the CPU entirely and leaves `l2_count` at 0, so `calloc(0, ...)` returns `NULL`. The filling pass then independently detects the per-core L2 from sysfs, takes the write branch, and dereferences `l2[++l2_index]` — a **NULL dereference / out-of-bounds write that crashes during initialization**.

### Fix

Move the sysfs / per-core check out of the `if (temp_l2.size != 0)` guard in the counting pass so both passes evaluate the **same condition**:

After the change, the counting and filling passes produce a consistent `l2_count` for the per-core case, so the allocation is sized correctly and the crash is eliminated.

### Scope

This patch only aligns the **per-core L2** condition that is the direct cause of the crash.

### Files changed

- `src/arm/linux/init.c` — counting-pass per-core L2 alignment.
