### PR TITLE
fix: calculate apic_bits using maximum thread index

### DIFF
--- a/src/x86/cache/deterministic.c
+++ b/src/x86/cache/deterministic.c
@@ -151,7 +151,7 @@ bool cpuinfo_x86_decode_cache_properties(struct cpuid_regs regs, struct cpuinfo_
 
 	const uint32_t level = (regs.eax >> 5) & UINT32_C(0x7);
 	const uint32_t cores = 1 + ((regs.eax >> 14) & UINT32_C(0x00000FFF));
-	const uint32_t apic_bits = bit_length(cores);
+	const uint32_t apic_bits = bit_length(cores - 1);
 
 	const uint32_t sets = 1 + regs.ecx;
 	const uint32_t line_size = 1 + (regs.ebx & UINT32_C(0x00000FFF));


### PR DESCRIPTION
Previously, the bitmask length for SMT cache grouping used the total core count. For a 2-thread cache, bit_length(2) allocated 2 bits, creating a mask that grouped 4 threads together. Changing this to bit_length(cores - 1) allocates exactly 1 bit, correctly masking 2 threads per cache instance.

fixes: #396