### PR TITLE
[CI] Fix Win UWP builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
         {
             "name": "x64-uwp",
             "displayName": "x64(uwp)",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "architecture": "x64",
             "binaryDir": "${sourceDir}/build/x64-uwp",
             "installDir": "${sourceDir}/install",


### PR DESCRIPTION
By bumping generator to VS2026, to match https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md