### PR TITLE
Fix Clang CFI type mismatch in src/arm/linux/cpuinfo.c

### DIFF
--- a/src/arm/linux/cpuinfo.c
+++ b/src/arm/linux/cpuinfo.c
@@ -726,8 +726,9 @@ struct proc_cpuinfo_parser_state {
 static bool parse_line(
 	const char* line_start,
 	const char* line_end,
-	struct proc_cpuinfo_parser_state state[restrict static 1],
+	void* context,
 	uint64_t line_number) {
+	struct proc_cpuinfo_parser_state* restrict state = (struct proc_cpuinfo_parser_state*)context;
 	/* Empty line. Skip. */
 	if (line_start == line_end) {
 		return true;
@@ -1019,5 +1020,5 @@ bool cpuinfo_arm_linux_parse_proc_cpuinfo(
 		.processors = processors,
 	};
 	return cpuinfo_linux_parse_multiline_file(
-		"/proc/cpuinfo", BUFFER_SIZE, (cpuinfo_line_callback)parse_line, &state);
+		"/proc/cpuinfo", BUFFER_SIZE, parse_line, &state);
 }


### PR DESCRIPTION
Change parse_line signature to accept void* and cast inside. Remove the cast when passing it to cpuinfo_linux_parse_multiline_file.

Fixes #402