### PR TITLE
Fix out-of-bounds write and lack of null-termination in /proc/cpuinfo…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,6 +805,14 @@ IF(CPUINFO_SUPPORTED_PLATFORM AND CPUINFO_BUILD_MOCK_TESTS)
     TARGET_LINK_LIBRARIES(zenfone-2e-test PRIVATE cpuinfo_mock gtest)
     ADD_TEST(NAME zenfone-2e-test COMMAND zenfone-2e-test)
   ENDIF()
+
+  IF(CPUINFO_TARGET_PROCESSOR MATCHES "^(armv[5-8].*|aarch64|arm64.*)$")
+    ADD_EXECUTABLE(repro-cpuinfo-test test/mock/repro_cpuinfo.c)
+    TARGET_INCLUDE_DIRECTORIES(repro-cpuinfo-test BEFORE PRIVATE src)
+    TARGET_LINK_LIBRARIES(repro-cpuinfo-test PRIVATE cpuinfo_mock)
+    ADD_TEST(NAME repro-cpuinfo-test COMMAND repro-cpuinfo-test)
+    SET_TESTS_PROPERTIES(repro-cpuinfo-test PROPERTIES WILL_FAIL TRUE)
+  ENDIF()
 ENDIF()
 
 # ---[ cpuinfo unit tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -811,7 +811,6 @@ IF(CPUINFO_SUPPORTED_PLATFORM AND CPUINFO_BUILD_MOCK_TESTS)
     TARGET_INCLUDE_DIRECTORIES(repro-cpuinfo-test BEFORE PRIVATE src)
     TARGET_LINK_LIBRARIES(repro-cpuinfo-test PRIVATE cpuinfo_mock)
     ADD_TEST(NAME repro-cpuinfo-test COMMAND repro-cpuinfo-test)
-    SET_TESTS_PROPERTIES(repro-cpuinfo-test PROPERTIES WILL_FAIL TRUE)
   ENDIF()
 ENDIF()
 

--- a/src/arm/linux/cpuinfo.c
+++ b/src/arm/linux/cpuinfo.c
@@ -872,31 +872,29 @@ static bool parse_line(
 				/* BogoMIPS is useless, don't parse */
 			} else if (memcmp(line_start, "Hardware", key_length) == 0) {
 				size_t value_length = value_end - value_start;
-				if (value_length > CPUINFO_HARDWARE_VALUE_MAX) {
+				if (value_length >= CPUINFO_HARDWARE_VALUE_MAX) {
 					cpuinfo_log_warning(
 						"length of Hardware value \"%.*s\" in /proc/cpuinfo exceeds limit (%d): truncating to the limit",
 						(int)value_length,
 						value_start,
-						CPUINFO_HARDWARE_VALUE_MAX);
-					value_length = CPUINFO_HARDWARE_VALUE_MAX;
-				} else {
-					state->hardware[value_length] = '\0';
+						CPUINFO_HARDWARE_VALUE_MAX - 1);
+					value_length = CPUINFO_HARDWARE_VALUE_MAX - 1;
 				}
+				state->hardware[value_length] = '\0';
 				memcpy(state->hardware, value_start, value_length);
 				cpuinfo_log_debug(
 					"parsed /proc/cpuinfo Hardware = \"%.*s\"", (int)value_length, value_start);
 			} else if (memcmp(line_start, "Revision", key_length) == 0) {
 				size_t value_length = value_end - value_start;
-				if (value_length > CPUINFO_REVISION_VALUE_MAX) {
+				if (value_length >= CPUINFO_REVISION_VALUE_MAX) {
 					cpuinfo_log_warning(
 						"length of Revision value \"%.*s\" in /proc/cpuinfo exceeds limit (%d): truncating to the limit",
 						(int)value_length,
 						value_start,
-						CPUINFO_REVISION_VALUE_MAX);
-					value_length = CPUINFO_REVISION_VALUE_MAX;
-				} else {
-					state->revision[value_length] = '\0';
+						CPUINFO_REVISION_VALUE_MAX - 1);
+					value_length = CPUINFO_REVISION_VALUE_MAX - 1;
 				}
+				state->revision[value_length] = '\0';
 				memcpy(state->revision, value_start, value_length);
 				cpuinfo_log_debug(
 					"parsed /proc/cpuinfo Revision = \"%.*s\"", (int)value_length, value_start);

--- a/test/mock/repro_cpuinfo.c
+++ b/test/mock/repro_cpuinfo.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <string.h>
+#include <cpuinfo-mock.h>
+#include <arm/linux/api.h>
+
+static struct cpuinfo_mock_file mock_files[] = {
+    {
+        .path = "/proc/cpuinfo",
+        .size = 0, // Will be initialized in main
+        .content =
+            "Hardware\t: "
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n",
+    },
+    {.path = NULL}};
+
+int main() {
+  mock_files[0].size = strlen(mock_files[0].content);
+  cpuinfo_mock_filesystem(mock_files);
+
+  char hardware[64];
+  char revision[9];
+  struct cpuinfo_arm_linux_processor processors[1];
+
+  printf("Calling cpuinfo_arm_linux_parse_proc_cpuinfo...\n");
+  cpuinfo_arm_linux_parse_proc_cpuinfo(hardware, revision, 1, processors);
+
+  printf("Hardware parsed: %s\n", hardware);
+
+  char expected[64];
+  memset(expected, 'A', 63);
+  expected[63] = '\0';
+
+  if (strcmp(hardware, expected) != 0) {
+    fprintf(stderr, "FAIL: expected length 63, got %s (length %zu)\n", hardware, strlen(hardware));
+    return 1;
+  }
+  printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
… parser

The parser for 'Hardware' and 'Revision' fields in src/arm/linux/cpuinfo.c had logic errors when handling values with length equal to or greater than the maximum buffer size.

1. If value_length == LIMIT, it would write '\0' at index LIMIT, which is out of bounds (buffer size is LIMIT).
2. If value_length > LIMIT, it would truncate to LIMIT, skip writing the null terminator, and copy LIMIT bytes, leaving the buffer non-null-terminated.

Fixed by checking if value_length >= LIMIT, truncating to LIMIT - 1 if so, and always writing the null terminator at the end of the (potentially truncated) copied value.

Fixes #407