### PR TITLE
fix off-by-one write in proc/cpuinfo hardware/revision parse

### DIFF
--- a/src/arm/linux/cpuinfo.c
+++ b/src/arm/linux/cpuinfo.c
@@ -872,7 +872,7 @@ static bool parse_line(
 				/* BogoMIPS is useless, don't parse */
 			} else if (memcmp(line_start, "Hardware", key_length) == 0) {
 				size_t value_length = value_end - value_start;
-				if (value_length > CPUINFO_HARDWARE_VALUE_MAX) {
+				if (value_length >= CPUINFO_HARDWARE_VALUE_MAX) {
 					cpuinfo_log_warning(
 						"length of Hardware value \"%.*s\" in /proc/cpuinfo exceeds limit (%d): truncating to the limit",
 						(int)value_length,
@@ -887,7 +887,7 @@ static bool parse_line(
 					"parsed /proc/cpuinfo Hardware = \"%.*s\"", (int)value_length, value_start);
 			} else if (memcmp(line_start, "Revision", key_length) == 0) {
 				size_t value_length = value_end - value_start;
-				if (value_length > CPUINFO_REVISION_VALUE_MAX) {
+				if (value_length >= CPUINFO_REVISION_VALUE_MAX) {
 					cpuinfo_log_warning(
 						"length of Revision value \"%.*s\" in /proc/cpuinfo exceeds limit (%d): truncating to the limit",
 						(int)value_length,


### PR DESCRIPTION
In `parse_line` (src/arm/linux/cpuinfo.c) the Hardware and Revision handlers null-terminate with `state->hardware[value_length] = '\0'` in the branch taken when the value fits. But the length guard uses `> CPUINFO_HARDWARE_VALUE_MAX` (and `> CPUINFO_REVISION_VALUE_MAX`), so a value whose length is exactly the max still takes that branch. Those destinations are exactly MAX bytes (64 and 9), so a `Hardware` line with a 64-byte value, or a `Revision` line with a 9-byte value, writes the terminator one byte past the buffer.

Change both comparisons to `>=` so an equal-length value goes through the truncation path instead. That leaves the buffer full and unterminated, which is already the contract downstream code relies on (the chipset decoders read these fields with `strnlen(buf, MAX)`), so keeping the bound at the write site is enough and no consumer needs to change.