### PR TITLE
Add AVX-VNNI-FP16 ISA feature detection and reporting to cpuinfo

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -893,6 +893,7 @@ struct cpuinfo_x86_isa {
 	bool amx_fp16;
 	bool avx_vnni_int8;
 	bool avx_vnni_int16;
+	bool avx_vnni_fp16;
 	bool avx_ne_convert;
 	bool hle;
 	bool rtm;
@@ -1481,6 +1482,17 @@ static inline bool cpuinfo_has_x86_avx_vnni_int8(void) {
 static inline bool cpuinfo_has_x86_avx_vnni_int16(void) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 	return cpuinfo_isa.avx_vnni_int16;
+#else
+	return false;
+#endif
+}
+
+/*
+ * AMD/Intel AVX Vector Neural Network Instructions (VNNI) FP16
+ */
+static inline bool cpuinfo_has_x86_avx_vnni_fp16(void) {
+#if CPUINFO_ARCH_X86_64
+	return cpuinfo_isa.avx_vnni_fp16;
 #else
 	return false;
 #endif

--- a/src/x86/isa.c
+++ b/src/x86/isa.c
@@ -588,6 +588,12 @@ struct cpuinfo_x86_isa cpuinfo_x86_detect_isa(
 	isa.avx_vnni_int16 = avx_regs && !!(structured_feature_info1.edx & UINT32_C(0x00000400));
 
 	/*
+	 * AVX_VNNI_FP16 instructions:
+	 * - AMD/Intel: eax[bit 1] in structured feature info (ecx = 1).
+	 */
+	isa.avx_vnni_fp16 = avx_regs && !!(structured_feature_info1.eax & UINT32_C(0x00000002));
+
+	/*
 	 * AVX_NE_CONVERT instructions:
 	 * - Intel: edx[bit 5] in structured feature info (ecx = 1).
 	 */

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -79,6 +79,7 @@ int main(int argc, char** argv) {
 	printf("\tAVXVNNI: %s\n", cpuinfo_has_x86_avxvnni() ? "yes" : "no");
 	printf("\tAVX_VNNI_INT8: %s\n", cpuinfo_has_x86_avx_vnni_int8() ? "yes" : "no");
 	printf("\tAVX_VNNI_INT16: %s\n", cpuinfo_has_x86_avx_vnni_int16() ? "yes" : "no");
+	printf("\tAVX_VNNI_FP16: %s\n", cpuinfo_has_x86_avx_vnni_fp16() ? "yes" : "no");
 	printf("\tAVX_NE_CONVERT: %s\n", cpuinfo_has_x86_avx_ne_convert() ? "yes" : "no");
 
 	printf("Multi-threading extensions:\n");


### PR DESCRIPTION
Expose AMD Zen 6 / Intel AVX-VNNI-FP16 (`avx_vnni_fp16`) instructions in `pytorch/cpuinfo`:
- Add `avx_vnni_fp16` boolean field to `struct cpuinfo_x86_isa`
- Add public inline accessor `cpuinfo_has_x86_avx_vnni_fp16(void)` (guarded for 64-bit mode)
- Detect support via CPUID Leaf 0x7, Sub-leaf 0x1 (ECX = 1), EAX bit 1 (`0x00000002`)
- Report `AVX_VNNI_FP16` support in `isa-info` tool