### PR TITLE
Add AMX-FP8 ISA feature detection and reporting to cpuinfo

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -891,6 +891,7 @@ struct cpuinfo_x86_isa {
 	bool amx_tile;
 	bool amx_int8;
 	bool amx_fp16;
+	bool amx_fp8;
 	bool avx_vnni_int8;
 	bool avx_vnni_int16;
 	bool avx_ne_convert;
@@ -1457,6 +1458,14 @@ static inline bool cpuinfo_has_x86_amx_int8(void) {
 static inline bool cpuinfo_has_x86_amx_fp16(void) {
 #if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
 	return cpuinfo_isa.amx_fp16;
+#else
+	return false;
+#endif
+}
+
+static inline bool cpuinfo_has_x86_amx_fp8(void) {
+#if CPUINFO_ARCH_X86 || CPUINFO_ARCH_X86_64
+	return cpuinfo_isa.amx_fp8;
 #else
 	return false;
 #endif

--- a/src/x86/isa.c
+++ b/src/x86/isa.c
@@ -48,6 +48,8 @@ struct cpuinfo_x86_isa cpuinfo_x86_detect_isa(
 		(max_base_index >= 7) ? cpuidex(7, 1) : (struct cpuid_regs){0, 0, 0, 0};
 	const struct cpuid_regs structured_feature_info2 =
 		(max_base_index >= 7) ? cpuidex(0x24, 0) : (struct cpuid_regs){0, 0, 0, 0};
+	const struct cpuid_regs tmm_info1 =
+		(max_base_index >= 0x1E) ? cpuidex(0x1E, 1) : (struct cpuid_regs){0, 0, 0, 0};
 
 	const uint32_t processor_capacity_info_index = UINT32_C(0x80000008);
 	const struct cpuid_regs processor_capacity_info = (max_extended_index >= processor_capacity_info_index)
@@ -574,6 +576,12 @@ struct cpuinfo_x86_isa cpuinfo_x86_detect_isa(
 	 * - Intel: eax[bit 21] in structured feature info (ecx = 1).
 	 */
 	isa.amx_fp16 = avx512_regs && !!(structured_feature_info1.eax & UINT32_C(0x00200000));
+
+	/*
+	 * AMX_FP8 instructions:
+	 * - Intel: eax[bit 4] in TMM feature info (leaf 0x1E, ecx = 1).
+	 */
+	isa.amx_fp8 = avx512_regs && !!(tmm_info1.eax & UINT32_C(0x00000010));
 
 	/*
 	 * AVX_VNNI_INT8 instructions:

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -76,6 +76,7 @@ int main(int argc, char** argv) {
 	printf("\tAMX_TILE: %s\n", cpuinfo_has_x86_amx_tile() ? "yes" : "no");
 	printf("\tAMX_INT8: %s\n", cpuinfo_has_x86_amx_int8() ? "yes" : "no");
 	printf("\tAMX_FP16: %s\n", cpuinfo_has_x86_amx_fp16() ? "yes" : "no");
+	printf("\tAMX_FP8: %s\n", cpuinfo_has_x86_amx_fp8() ? "yes" : "no");
 	printf("\tAVXVNNI: %s\n", cpuinfo_has_x86_avxvnni() ? "yes" : "no");
 	printf("\tAVX_VNNI_INT8: %s\n", cpuinfo_has_x86_avx_vnni_int8() ? "yes" : "no");
 	printf("\tAVX_VNNI_INT16: %s\n", cpuinfo_has_x86_avx_vnni_int16() ? "yes" : "no");


### PR DESCRIPTION
Expose Intel AMX-FP8 (`amx_fp8`) instructions in `pytorch/cpuinfo`:
- Add `amx_fp8` boolean field to `struct cpuinfo_x86_isa`
- Add public inline accessor `cpuinfo_has_x86_amx_fp8(void)`
- Detect support via CPUID Leaf 0x1E, Sub-leaf 1 (ECX = 1), EAX bit 4 (`0x00000010`) and AVX512/AMX registers
- Report `AMX_FP8` support in `isa-info` tool