### PR TITLE
fix out-of-bounds l2 cache write in cpuinfo_arm_linux_init

### DIFF
--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -806,22 +806,26 @@ void cpuinfo_arm_linux_init(void) {
 			 * between all cores
 			 */
 			shared_l3 = false;
-			if (temp_l2.size != 0) {
-				/* Check if L2 is per-core using sysfs */
-				uint32_t sysfs_l2_size = cpuinfo_linux_read_sysfs_cache_size(
-					arm_linux_processors[i].system_processor_id, 2);
-				bool l2_is_per_core = (sysfs_l2_size > 0) &&
-					cpuinfo_linux_is_l2_per_core(arm_linux_processors[i].system_processor_id);
-
-				if (l2_is_per_core) {
-					/* L2 is private to each core */
+			/* The population pass overrides the decoded L2 size with the
+			 * value from sysfs; mirror that here so the count matches. A
+			 * core whose decoded L2 is zero but which reports an L2 size
+			 * in sysfs would otherwise be skipped here yet allocated a
+			 * slot below, overflowing the l2 array. */
+			uint32_t sysfs_l2_size =
+				cpuinfo_linux_read_sysfs_cache_size(arm_linux_processors[i].system_processor_id, 2);
+			if (sysfs_l2_size > 0) {
+				temp_l2.size = sysfs_l2_size;
+			}
+			bool l2_is_per_core = (sysfs_l2_size > 0) &&
+				cpuinfo_linux_is_l2_per_core(arm_linux_processors[i].system_processor_id);
+			if (l2_is_per_core) {
+				/* L2 is private to each core */
+				l2_count += 1;
+			} else if (temp_l2.size != 0) {
+				/* Assume L2 is shared by cores in the same cluster */
+				if (arm_linux_processors[i].package_leader_id ==
+				    arm_linux_processors[i].system_processor_id) {
 					l2_count += 1;
-				} else {
-					/* Assume L2 is shared by cores in the same cluster */
-					if (arm_linux_processors[i].package_leader_id ==
-					    arm_linux_processors[i].system_processor_id) {
-						l2_count += 1;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
The L2 cache count and population passes in cpuinfo_arm_linux_init disagree on when a core gets an L2 entry:
- counting keys off the decoded L2 size, but population overrides it with the size from sysfs (cache/index2/size)
- a core whose built-in decode reports no L2 (ARM11, or an unrecognized ARMv6 core) but whose sysfs exposes an L2 size is skipped while counting yet still gets a slot while populating
- l2_index then advances past l2_count, writing past the end of the calloc'd l2 array, or through a NULL l2 when the count is zero (the L2 writes are unguarded, unlike the L3 writes)

Applying the same sysfs size override in the counting pass keeps l2_count aligned with the number of entries written.