### PR TITLE
cast to unsigned char before toupper in cache size parser

### DIFF
--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -46,7 +46,7 @@ static bool cache_size_parser(const char* filename, const char* text_start, cons
 		return false;
 	}
 	uint32_t multiplier = 1024;
-	if (p < text_end && toupper(*p) == 'M') {
+	if (p < text_end && toupper((unsigned char)*p) == 'M') {
 		multiplier = 1024 * 1024;
 	}
 	*size_ptr = value * multiplier;


### PR DESCRIPTION
toupper() in cache_size_parser gets a plain char, which is signed on the ARM/Android targets this file builds for:
- the argument is the first non-digit byte of the sysfs cache-size value (/sys/.../cache/indexN/size), so any byte >= 0x80 reaches toupper as a negative int
- C11 7.4p1 requires the argument to be representable as unsigned char or equal to EOF; bionic and musl index their ctype table directly with it, so a negative value is an out-of-bounds read
- cast to unsigned char, the standard guard for ctype on possibly-signed input