### PR TITLE
linux: treat a negative topology id as unavailable, not a parse error

### DIFF
--- a/src/linux/processors.c
+++ b/src/linux/processors.c
@@ -94,7 +94,7 @@ static const uint32_t default_max_processors_count = CPU_SETSIZE;
 
 static bool uint32_parser(const char* filename, const char* text_start, const char* text_end, void* context) {
 	if (text_start == text_end) {
-		cpuinfo_log_error("failed to parse file %s: file is empty", KERNEL_MAX_FILENAME);
+		cpuinfo_log_error("failed to parse file %s: file is empty", filename);
 		return false;
 	}
 
@@ -123,6 +123,20 @@ static bool uint32_parser(const char* filename, const char* text_start, const ch
 	uint32_t* kernel_max_ptr = (uint32_t*)context;
 	*kernel_max_ptr = kernel_max;
 	return true;
+}
+
+/*
+ * The kernel exposes a topology id as -1 when it has no topology information
+ * for the processor. That is a sentinel rather than a malformed file, so treat
+ * it as "value unavailable" instead of reporting a parse error for every
+ * processor. A topology id is never legitimately negative.
+ */
+static bool topology_id_parser(const char* filename, const char* text_start, const char* text_end, void* context) {
+	if (text_start != text_end && *text_start == '-') {
+		cpuinfo_log_debug("file %s reports no topology information for this processor", filename);
+		return false;
+	}
+	return uint32_parser(filename, text_start, text_end, context);
 }
 
 uint32_t cpuinfo_linux_get_max_processors_count(void) {
@@ -240,7 +254,7 @@ bool cpuinfo_linux_get_processor_core_id(uint32_t processor, uint32_t core_id_pt
 	}
 
 	uint32_t core_id;
-	if (cpuinfo_linux_parse_small_file(core_id_filename, CORE_ID_FILESIZE, uint32_parser, &core_id)) {
+	if (cpuinfo_linux_parse_small_file(core_id_filename, CORE_ID_FILESIZE, topology_id_parser, &core_id)) {
 		cpuinfo_log_debug(
 			"parsed core id value of %" PRIu32 " for logical processor %" PRIu32 " from %s",
 			core_id,
@@ -265,7 +279,7 @@ bool cpuinfo_linux_get_processor_package_id(uint32_t processor, uint32_t package
 	}
 
 	uint32_t package_id;
-	if (cpuinfo_linux_parse_small_file(package_id_filename, PACKAGE_ID_FILESIZE, uint32_parser, &package_id)) {
+	if (cpuinfo_linux_parse_small_file(package_id_filename, PACKAGE_ID_FILESIZE, topology_id_parser, &package_id)) {
 		cpuinfo_log_debug(
 			"parsed package id value of %" PRIu32 " for logical processor %" PRIu32 " from %s",
 			package_id,


### PR DESCRIPTION
The kernel exposes `core_id` and `physical_package_id` as `-1` when it has no topology information for a processor. Both are parsed with `uint32_parser`, which rejects any non-digit lead byte, so every such processor produces an **error-level** log claiming the sysfs file is malformed.

Observed on a native riscv64 board (SiFive U74-class, kernel 5.10.113), which reports `core_id = -1` on all four cores:

```
Error in cpuinfo: failed to parse file /sys/devices/system/cpu/cpu0/topology/core_id: "-1" is not an unsigned number
Error in cpuinfo: failed to parse file /sys/devices/system/cpu/cpu1/topology/core_id: "-1" is not an unsigned number
Error in cpuinfo: failed to parse file /sys/devices/system/cpu/cpu2/topology/core_id: "-1" is not an unsigned number
Error in cpuinfo: failed to parse file /sys/devices/system/cpu/cpu3/topology/core_id: "-1" is not an unsigned number
```

`-1` is a documented sentinel meaning "not populated", not corruption, so this is a false alarm rather than a real parse failure.

## Root cause

`parse_number` (`src/linux/processors.c`) stops at the first non-digit. For `-1` it stops immediately on the `-`, leaving `parsed_end == text_start`, which `uint32_parser` reports as `"is not an unsigned number"` at error level.

## The change

Add a `topology_id_parser` wrapper used by the two topology getters. A topology id is never legitimately negative, so a leading `-` is reported as "value unavailable" at debug level instead. **The return value is unchanged** (`false`, since the id genuinely is unavailable), so no caller behavior changes. Only the false alarm goes away.

`uint32_parser` continues to back `kernel_max` and the three frequency getters, where a negative value would still be a genuine error.

`physical_package_id` parsed fine on the board above, but is exposed to the same sentinel through the same kernel mechanism, so it is covered for consistency.

## Also fixed

The empty-file branch in `uint32_parser` hardcoded `KERNEL_MAX_FILENAME` even though the parser is shared by six call sites, so an empty `core_id` file would have blamed `/sys/devices/system/cpu/kernel_max`. It now reports the `filename` it was given.

## Test plan

Compiled the real `src/linux/processors.c` into a harness driving its actual static parsers (stubbing only the sysfs reader), so this exercises the shipped code rather than a copy:

```
clang -DCPUINFO_LOG_LEVEL=5 -I src -I include -o t t.c src/log.c
```

Before, reproducing the board output exactly:

```
Error in cpuinfo: failed to parse file .../topology/core_id: "-1" is not an unsigned number
  core_id "-1"  -> ok=false
  core_id "0"   -> ok=true  value=0
```

After:

```
Debug (cpuinfo): file .../topology/core_id reports no topology information for this processor
  core_id "-1"  -> ok=false      (unchanged return, ERROR downgraded to DEBUG)
  core_id "0"   -> ok=true  value=0
  core_id "3"   -> ok=true  value=3
  core_id "-10" -> ok=false
```
