### PR TITLE
Guard _DEFAULT_SOURCE with #ifndef in src/api.c

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -1,5 +1,7 @@
 /* for syscall() */
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
Fix build error:

cpuinfo/src/api.c:2:9: error: '_DEFAULT_SOURCE' macro redefined [-Werror,-Wmacro-redefined]
    2 | #define _DEFAULT_SOURCE
      |         ^

add an #ifndef around the define

Fixes #171
