### PR TITLE
Detect Apple M5 Pro / Max (Sotra) super and performance cores

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -645,6 +645,11 @@ enum cpuinfo_uarch {
 	/** Apple M4 processor (little cores). */
 	cpuinfo_uarch_donan_sawtooth = 0x00700309,
 
+	/** Apple M5 Pro / Max processor (super cores). */
+	cpuinfo_uarch_sotra_super = 0x0070030A,
+	/** Apple M5 Pro / Max processor (performance cores). */
+	cpuinfo_uarch_sotra_performance = 0x0070030B,
+
 	/** Cavium ThunderX. */
 	cpuinfo_uarch_thunderx = 0x00800100,
 	/** Cavium ThunderX2 (originally Broadcom Vulkan). */

--- a/src/arm/mach/init.c
+++ b/src/arm/mach/init.c
@@ -72,6 +72,10 @@
 #ifndef CPUFAMILY_ARM_HIDRA
 #define CPUFAMILY_ARM_HIDRA 0x1d5a87e8
 #endif
+// M5 Pro / M5 Max
+#ifndef CPUFAMILY_ARM_SOTRA
+#define CPUFAMILY_ARM_SOTRA 0xf76c5b1a
+#endif
 // A19
 #ifndef CPUFAMILY_ARM_TILOS
 #define CPUFAMILY_ARM_TILOS 0x01d7a72b
@@ -184,6 +188,12 @@ static enum cpuinfo_uarch decode_uarch(uint32_t cpu_family, uint32_t core_index,
 		case CPUFAMILY_ARM_HIDRA: /* M5 */
 			/* 10-core: 4x Tilos Everest v4 + 6x Tilos Sawtooth v4 */
 			return core_index + 6 < core_count ? cpuinfo_uarch_tilos_everest : cpuinfo_uarch_tilos_sawtooth;
+		case CPUFAMILY_ARM_SOTRA: /* M5 Pro / M5 Max */
+			/* Pro 15-core: 5x Sotra Super + 10x Sotra Performance */
+			/* Max 18-core: 6x Sotra Super + 12x Sotra Performance */
+			return (core_count > 15 ? core_index + 12 : core_index + 10) < core_count
+				? cpuinfo_uarch_sotra_super
+				: cpuinfo_uarch_sotra_performance;
 
 		default:
 			/* Use hw.cpusubtype for detection */

--- a/tools/cpu-info.c
+++ b/tools/cpu-info.c
@@ -318,25 +318,29 @@ static const char* uarch_to_string(enum cpuinfo_uarch uarch) {
 		case cpuinfo_uarch_sawtooth:
 			return "Sawtooth";
 		case cpuinfo_uarch_coll_everest:
-			return "Coll_Everest";
+			return "Coll Everest";
 		case cpuinfo_uarch_coll_sawtooth:
-			return "Coll_Sawtooth";
+			return "Coll Sawtooth";
 		case cpuinfo_uarch_tupai_everest:
-			return "Tupai_Everest";
+			return "Tupai Everest";
 		case cpuinfo_uarch_tupai_sawtooth:
-			return "Tupai_Sawtooth";
+			return "Tupai Sawtooth";
 		case cpuinfo_uarch_tahiti_everest:
-			return "Tahiti_Everest";
+			return "Tahiti Everest";
 		case cpuinfo_uarch_tahiti_sawtooth:
-			return "Tahiti_Sawtooth";
+			return "Tahiti Sawtooth";
 		case cpuinfo_uarch_tilos_everest:
-			return "Tilos_Everest";
+			return "Tilos Everest";
 		case cpuinfo_uarch_tilos_sawtooth:
-			return "Tilos_Sawtooth";
+			return "Tilos Sawtooth";
 		case cpuinfo_uarch_donan_everest:
 			return "Donan Everest";
 		case cpuinfo_uarch_donan_sawtooth:
 			return "Donan Sawtooth";
+		case cpuinfo_uarch_sotra_super:
+			return "Sotra Super";
+		case cpuinfo_uarch_sotra_performance:
+			return "Sotra Performance";
 		case cpuinfo_uarch_thunderx:
 			return "ThunderX";
 		case cpuinfo_uarch_thunderx2:


### PR DESCRIPTION
Add microarchitecture detection for Apple M5 Pro and M5 Max (Sotra SoC / CPUFAMILY_ARM_SOTRA).

- Add `cpuinfo_uarch_sotra_super` and `cpuinfo_uarch_sotra_performance` enums.
- Detect 15-core (5 Super + 10 Performance) and 18-core (6 Super + 12 Performance) configurations on macOS/XNU.
- Make displayed Apple uarch names consistently use space, not underscore.
- Tested `tools/cpu-info.c` on 14" MacBook Pro:
```
./cpu_info 
Packages:
	0: Apple M5 Pro
Microarchitectures:
	5x Sotra Super
	10x Sotra Performance
Cores:
	0: 1 processor (0), Apple Sotra Super
	1: 1 processor (1), Apple Sotra Super
	2: 1 processor (2), Apple Sotra Super
	3: 1 processor (3), Apple Sotra Super
	4: 1 processor (4), Apple Sotra Super
	5: 1 processor (5), Apple Sotra Performance
	6: 1 processor (6), Apple Sotra Performance
	7: 1 processor (7), Apple Sotra Performance
	8: 1 processor (8), Apple Sotra Performance
	9: 1 processor (9), Apple Sotra Performance
	10: 1 processor (10), Apple Sotra Performance
	11: 1 processor (11), Apple Sotra Performance
	12: 1 processor (12), Apple Sotra Performance
	13: 1 processor (13), Apple Sotra Performance
	14: 1 processor (14), Apple Sotra Performance
Clusters:
	0: 5 processors (0-4),	0: 5 cores (0-4), Apple Sotra Super
	1: 10 processors (5-14),	1: 10 cores (5-14), Apple Sotra Performance
```

Resolves https://github.com/pytorch/cpuinfo/issues/423