### PR TITLE
Rename ARM FP8 inline helpers to NEON naming conventions

### DIFF
--- a/include/cpuinfo.h
+++ b/include/cpuinfo.h
@@ -2092,7 +2092,11 @@ static inline bool cpuinfo_has_arm_fp8(void) {
 #endif
 }
 
-static inline bool cpuinfo_has_arm_f8dot(void) {
+/* For backward compatibility */
+#define cpuinfo_has_arm_f8dot cpuinfo_has_arm_neon_f8dot4
+#define cpuinfo_has_arm_f8mm cpuinfo_has_arm_neon_f8mm
+
+static inline bool cpuinfo_has_arm_neon_f8dot4(void) {
 #if CPUINFO_ARCH_ARM64
 	return cpuinfo_isa.f8dot;
 #else
@@ -2100,7 +2104,7 @@ static inline bool cpuinfo_has_arm_f8dot(void) {
 #endif
 }
 
-static inline bool cpuinfo_has_arm_f8mm(void) {
+static inline bool cpuinfo_has_arm_neon_f8mm(void) {
 #if CPUINFO_ARCH_ARM64
 	return cpuinfo_isa.f8mm;
 #else

--- a/test/mock/pixel-8.cc
+++ b/test/mock/pixel-8.cc
@@ -590,8 +590,16 @@ TEST(ISA, f8dot) {
 	ASSERT_FALSE(cpuinfo_has_arm_f8dot());
 }
 
+TEST(ISA, neon_f8dot4) {
+	ASSERT_FALSE(cpuinfo_has_arm_neon_f8dot4());
+}
+
 TEST(ISA, f8mm) {
 	ASSERT_FALSE(cpuinfo_has_arm_f8mm());
+}
+
+TEST(ISA, neon_f8mm) {
+	ASSERT_FALSE(cpuinfo_has_arm_neon_f8mm());
 }
 
 TEST(L1I, count) {

--- a/tools/isa-info.c
+++ b/tools/isa-info.c
@@ -171,8 +171,8 @@ int main(int argc, char** argv) {
 	printf("\tARM v8.3 JS conversion: %s\n", cpuinfo_has_arm_jscvt() ? "yes" : "no");
 	printf("\tARM v8.3 complex: %s\n", cpuinfo_has_arm_fcma() ? "yes" : "no");
 	printf("\tARM v8.7 FP8: %s\n", cpuinfo_has_arm_fp8() ? "yes" : "no");
-	printf("\tARM v8.7 FP8 dot product: %s\n", cpuinfo_has_arm_f8dot() ? "yes" : "no");
-	printf("\tARM v8.7 FP8 matrix multiplication: %s\n", cpuinfo_has_arm_f8mm() ? "yes" : "no");
+	printf("\tARM v8.7 FP8 dot product: %s\n", cpuinfo_has_arm_neon_f8dot4() ? "yes" : "no");
+	printf("\tARM v8.7 FP8 matrix multiplication: %s\n", cpuinfo_has_arm_neon_f8mm() ? "yes" : "no");
 
 	printf("SIMD extensions:\n");
 	printf("\tARM SVE: %s\n", cpuinfo_has_arm_sve() ? "yes" : "no");


### PR DESCRIPTION
Rename `cpuinfo_has_arm_f8dot` and `cpuinfo_has_arm_f8mm` to `cpuinfo_has_arm_neon_f8dot4` and `cpuinfo_has_arm_neon_f8mm`.

ARM type support refers to scalar ARM, not NEON. FP8 scalar conversions are checked via `cpuinfo_has_arm_fp8`, while the dot product and matrix multiplication instructions are NEON/SIMD.

Details:
- Add backward compatibility macros:
  `#define cpuinfo_has_arm_f8dot cpuinfo_has_arm_neon_f8dot4`
  `#define cpuinfo_has_arm_f8mm cpuinfo_has_arm_neon_f8mm`
- Rename inline helpers to `cpuinfo_has_arm_neon_f8dot4` and `cpuinfo_has_arm_neon_f8mm`
- Update callers in `tools/isa-info.c`
- Add test coverage in `test/mock/pixel-8.cc`

Fixes https://github.com/pytorch/cpuinfo/issues/427