### PR TITLE
Fix C++17 array initializer warnings

### DIFF
--- a/test/arm-cache.cc
+++ b/test/arm-cache.cc
@@ -359,12 +359,7 @@ TEST(QUALCOMM, snapdragon_626) {
 		.vendor = cpuinfo_arm_chipset_vendor_qualcomm,
 		.series = cpuinfo_arm_chipset_series_qualcomm_msm,
 		.model = 8953,
-		.suffix =
-			{
-				[0] = 'P',
-				[1] = 'R',
-				[2] = 'O',
-			},
+		.suffix = "PRO",
 	};
 
 	struct cpuinfo_cache big_l1i = {0};
@@ -615,12 +610,7 @@ TEST(QUALCOMM, snapdragon_653) {
 		.vendor = cpuinfo_arm_chipset_vendor_qualcomm,
 		.series = cpuinfo_arm_chipset_series_qualcomm_msm,
 		.model = 8976,
-		.suffix =
-			{
-				[0] = 'P',
-				[1] = 'R',
-				[2] = 'O',
-			},
+		.suffix = "PRO",
 	};
 
 	struct cpuinfo_cache big_l1i = {0};
@@ -862,15 +852,7 @@ TEST(QUALCOMM, snapdragon_821) {
 		.vendor = cpuinfo_arm_chipset_vendor_qualcomm,
 		.series = cpuinfo_arm_chipset_series_qualcomm_msm,
 		.model = 8996,
-		.suffix =
-			{
-				[0] = 'P',
-				[1] = 'R',
-				[2] = 'O',
-				[3] = '-',
-				[4] = 'A',
-				[5] = 'C',
-			},
+		.suffix = "PRO-AC",
 	};
 
 	struct cpuinfo_cache big_l1i = {0};
@@ -1235,10 +1217,7 @@ TEST(MEDIATEK, mediatek_mt8173c) {
 		.vendor = cpuinfo_arm_chipset_vendor_mediatek,
 		.series = cpuinfo_arm_chipset_series_mediatek_mt,
 		.model = 8173,
-		.suffix =
-			{
-				[0] = 'C',
-			},
+		.suffix = "C",
 	};
 
 	struct cpuinfo_cache big_l1i = {0};


### PR DESCRIPTION
Fixes warnings like because C++17 is not C99 compatible...
```
/home/runner/work/cpuinfo/cpuinfo/test/arm-cache.cc:364:5: warning: array designators are a C99 extension [-Wc99-designator]
  364 |                                 [0] = 'P',
      |                                 ^~~
/home/runner/work/cpuinfo/cpuinfo/test/arm-cache.cc:620:5: warning: array designators are a C99 extension [-Wc99-designator]
  620 |                                 [0] = 'P',
      |                                 ^~~
/home/runner/work/cpuinfo/cpuinfo/test/arm-cache.cc:867:5: warning: array designators are a C99 extension [-Wc99-designator]
  867 |                                 [0] = 'P',
      |                                 ^~~
/home/runner/work/cpuinfo/cpuinfo/test/arm-cache.cc:1240:5: warning: array designators are a C99 extension [-Wc99-designator]
 1240 |                                 [0] = 'C',
      |                                 ^~~
```