### PR TITLE
Guard processors[i].cache.l2 assignment in cpuinfo_arm_linux_init

### DIFF
--- a/src/arm/linux/init.c
+++ b/src/arm/linux/init.c
@@ -943,7 +943,9 @@ void cpuinfo_arm_linux_init(void) {
 					.processor_count = arm_linux_processors[i].package_processor_count,
 				};
 			}
-			processors[i].cache.l2 = l2 + l2_index;
+			if (l2 != NULL && l2_index < l2_count) {
+				processors[i].cache.l2 = l2 + l2_index;
+			}
 		}
 	}
 

--- a/test/init.cc
+++ b/test/init.cc
@@ -140,11 +140,15 @@ TEST(PROCESSOR, consistent_l1d) {
 
 TEST(PROCESSOR, consistent_l2) {
 	ASSERT_TRUE(cpuinfo_initialize());
+	const struct cpuinfo_cache* l2_caches = cpuinfo_get_l2_caches();
+	const uint32_t l2_count = cpuinfo_get_l2_caches_count();
 	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
 		const cpuinfo_processor* processor = cpuinfo_get_processor(i);
 		ASSERT_TRUE(processor);
 		const cpuinfo_cache* l2 = processor->cache.l2;
 		if (l2 != nullptr) {
+			EXPECT_GE(l2, l2_caches);
+			EXPECT_LT(l2, l2_caches + l2_count);
 			EXPECT_GE(i, l2->processor_start);
 			EXPECT_LT(i, l2->processor_start + l2->processor_count);
 		}
@@ -154,11 +158,15 @@ TEST(PROCESSOR, consistent_l2) {
 
 TEST(PROCESSOR, consistent_l3) {
 	ASSERT_TRUE(cpuinfo_initialize());
+	const struct cpuinfo_cache* l3_caches = cpuinfo_get_l3_caches();
+	const uint32_t l3_count = cpuinfo_get_l3_caches_count();
 	for (uint32_t i = 0; i < cpuinfo_get_processors_count(); i++) {
 		const cpuinfo_processor* processor = cpuinfo_get_processor(i);
 		ASSERT_TRUE(processor);
 		const cpuinfo_cache* l3 = processor->cache.l3;
 		if (l3 != nullptr) {
+			EXPECT_GE(l3, l3_caches);
+			EXPECT_LT(l3, l3_caches + l3_count);
 			EXPECT_GE(i, l3->processor_start);
 			EXPECT_LT(i, l3->processor_start + l3->processor_count);
 		}


### PR DESCRIPTION
### Problem
On ARM Linux platforms where L2 is assumed to be shared by cores in the same cluster (`else if (temp_l2.size != 0)`), `l2_index` is only incremented when `arm_linux_processors[i].package_leader_id == arm_linux_processors[i].system_processor_id`.

If cluster topology information is incomplete or unavailable (e.g. offline cluster leader core, or SoC topology where the package leader ID does not match any online processor), `l2_index` remains uninitialized at `UINT32_MAX`.

When this happens, the unguarded assignment:
```c
processors[i].cache.l2 = l2 + l2_index;
```
assigns an invalid out-of-bounds pointer (`l2 + UINT32_MAX` or `NULL + UINT32_MAX`). Downstream callers (such as Ruy, LiteRT/TFLite, XNNPACK, PyTorch) check `if (processor->cache.l2 != nullptr)` and then dereference members like `cache->processor_count`, causing a fatal SIGSEGV.

### Solution
1. Guard the `processors[i].cache.l2` assignment with `if (l2 != NULL && l2_index < l2_count)`, matching the same bounds validation pattern already used for L3 (`else if (l3_index < l3_count)`). If `l2` is not allocated or `l2_index` is uninitialized, `cache.l2` safely remains `NULL`.
2. Add pointer bounds checks (`EXPECT_GE(l2, l2_caches); EXPECT_LT(l2, l2_caches + l2_count); `) in `test/init.cc` for `consistent_l2` and `consistent_l3`.

Co-authored-by: Alexandru Paiu <apaiu@google.com>